### PR TITLE
Clean up and exit on Ctrl-Q

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -42,6 +42,14 @@ class Application(QtGui.QApplication):
         if platform == 'Tails' or platform == 'Linux':
             self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
         QtGui.QApplication.__init__(self, sys.argv)
+        self.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if (event.type() == QtCore.QEvent.KeyPress and
+            event.key() == QtCore.Qt.Key_Q and
+            event.modifiers() == QtCore.Qt.ControlModifier):
+                self.quit()
+        return False
 
 
 class OnionShareGui(QtGui.QWidget):


### PR DESCRIPTION
Expected GUI behavior. Particularly helpful if using window managers that don't provide a close button.