### PR TITLE
Remove unnecessary status_bar.showMessage

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -147,7 +147,6 @@ class OnionShareGui(QtGui.QWidget):
         self.status_bar.showMessage(strings._('gui_starting_server1', True))
         self.app.choose_port()
         try:
-            self.status_bar.showMessage(strings._('gui_starting_server1', True))
             self.app.start_hidden_service(gui=True)
         except onionshare.hs.NoTor as e:
             alert(e.args[0], QtGui.QMessageBox.Warning)


### PR DESCRIPTION
status_bar.showMessage is already called with the same message at the
beginning of start_server, so there is no reason to call it again in the
try block.