### PR TITLE
Revert to using wait_for_hs for ephemeral HS

### DIFF
--- a/onionshare/hs.py
+++ b/onionshare/hs.py
@@ -87,7 +87,7 @@ class HS(object):
         print strings._("connecting_ctrlport").format(int(port))
         if self.supports_ephemeral:
             print strings._('using_ephemeral')
-            res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication = True)
+            res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication = False)
             self.service_id = res.content()[0][2].split('=')[1]
             onion_host = res.content()[0][2].split('=')[1] + '.onion'
             return onion_host

--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -159,10 +159,9 @@ def main(cwd=None):
     try:  # Trap Ctrl-C
         # wait for hs, only if using old version of tor
         if not app.local_only:
-            if not app.hs.supports_ephemeral:
-                ready = app.hs.wait_for_hs(app.onion_host)
-                if not ready:
-                    sys.exit()
+            ready = app.hs.wait_for_hs(app.onion_host)
+            if not ready:
+                sys.exit()
 
         print strings._("give_this_url")
         print 'http://{0:s}/{1:s}'.format(app.onion_host, web.slug)

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -169,9 +169,8 @@ class OnionShareGui(QtGui.QWidget):
 
             # wait for hs
             if not self.app.local_only:
-                if not self.app.hs.supports_ephemeral:
-                    self.status_bar.showMessage(strings._('gui_starting_server3', True))
-                    self.app.hs.wait_for_hs(self.app.onion_host)
+                self.status_bar.showMessage(strings._('gui_starting_server3', True))
+                self.app.hs.wait_for_hs(self.app.onion_host)
 
             # done
             self.start_server_finished.emit()


### PR DESCRIPTION
Using `await_publication = True` blocks inside stem until the hidden
service is published, which makes OnionShare appear to hang. This is a
quick fix that reverts to using `wait_for_hs` for ephemeral hidden
services (as well as non-ephemeral hidden services), which avoids
blocking OnionShare.

Fixes #242 as described in https://github.com/micahflee/onionshare/issues/242#issuecomment-166798279, although in the long run it would be preferable to use `await_publication=True` with `create_ephemeral_hidden_service`. In order to do this without blocking, we would need to run it in a thread and return control to the main thread. Doing that would involve returning a thread object from `start_hidden_service` for the ephemeral case, and then joining it in the appropriate location in `start_server`.