### PR TITLE
add python3-nose for ubuntu 16.04 to Build.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ After that you can try both the CLI and the GUI version of OnionShare:
 A script to build a .deb package and install OnionShare easily is also provided for your convenience:
 
 ```sh
-sudo apt-get install -y build-essential fakeroot python3-all python3-stdeb dh-python python-nautilus
+sudo apt-get install -y build-essential fakeroot python3-all python3-stdeb dh-python python-nautilus python3-nose
 ./install/build_deb.sh
 sudo dpkg -i deb_dist/onionshare_*.deb
 ```


### PR DESCRIPTION
on Ubuntu 16.04 python3-nose was required to proceed (on 14.04 python3-stdeb was just missing entierly)
Don't know if you want to amend the instructions. Feel free to reject :) 
(tho seems like it's required for the tests as you mention below so probably required here for Debian as well)