### PR TITLE
Wrap progress bar

### DIFF
--- a/onionshare_gui/downloads.py
+++ b/onionshare_gui/downloads.py
@@ -56,7 +56,7 @@ class Download(object):
             elapsed = time.time() - self.started
             if elapsed < 10:
                 # Wait a couple of seconds for the download rate to stabilize.
-                # This prevents an "Windows copy dialog"-esque experience at
+                # This prevents a "Windows copy dialog"-esque experience at
                 # the beginning of the download.
                 pb_fmt = strings._('gui_download_progress_starting').format(
                     helpers.human_readable_filesize(downloaded_bytes))

--- a/onionshare_gui/downloads.py
+++ b/onionshare_gui/downloads.py
@@ -103,7 +103,7 @@ class Downloads(QtWidgets.QVBoxLayout):
         # add it to the list
         download = Download(download_id, total_bytes)
         self.downloads[download_id] = download
-        self.addWidget(download.progress_bar)
+        self.insertWidget(-1, download.progress_bar)
 
     def update_download(self, download_id, downloaded_bytes):
         """

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -98,6 +98,13 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         # downloads
         self.downloads = Downloads()
+        self.downloads_layout = QtWidgets.QGroupBox()
+        self.downloads_layout.setLayout(self.downloads)
+        self.downloads_layout_container = QtWidgets.QScrollArea()
+        self.downloads_layout_container.setWidget(self.downloads_layout)
+        self.downloads_layout_container.setWidgetResizable(True)
+        self.downloads_layout_container.setFixedHeight(80)
+        self.vbar = self.downloads_layout_container.verticalScrollBar()
 
         # options
         self.options = Options(web, self.app)
@@ -108,19 +115,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
         version_label = QtWidgets.QLabel('v{0:s}'.format(helpers.get_version()))
         version_label.setStyleSheet('color: #666666; padding: 0 10px;')
         self.status_bar.addPermanentWidget(version_label)
-        self.setStatusBar(self.status_bar)
+        self.setStatusBar(self.status_bar) 
 
         # main layout
         self.layout = QtWidgets.QVBoxLayout()
-        
-        self.downloads_layout = QtWidgets.QGroupBox()
-        self.downloads_layout.setLayout(self.downloads)
-        self.downloads_layout_container = QtWidgets.QScrollArea()
-        self.downloads_layout_container.setWidget(self.downloads_layout)
-        self.downloads_layout_container.setWidgetResizable(True)
-        self.downloads_layout_container.setFixedHeight(80)
-        self.vbar = self.downloads_layout_container.verticalScrollBar()
-
         self.layout.addLayout(self.file_selection)
         self.layout.addLayout(self.server_status)
         self.layout.addWidget(self.filesize_warning)
@@ -219,7 +217,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 events.append(r)
             except web.queue.Empty:
                 done = True
+
+        # scroll to the bottom of the dl progress bar log pane
         self.vbar.setValue(self.vbar.maximum())
+
         for event in events:
             if event["type"] == web.REQUEST_LOAD:
                 self.status_bar.showMessage(strings._('download_page_loaded', True))

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -112,10 +112,19 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         # main layout
         self.layout = QtWidgets.QVBoxLayout()
+        
+        self.downloads_layout = QtWidgets.QGroupBox()
+        self.downloads_layout.setLayout(self.downloads)
+        self.downloads_layout_container = QtWidgets.QScrollArea()
+        self.downloads_layout_container.setWidget(self.downloads_layout)
+        self.downloads_layout_container.setWidgetResizable(True)
+        self.downloads_layout_container.setFixedHeight(80)
+        self.vbar = self.downloads_layout_container.verticalScrollBar()
+
         self.layout.addLayout(self.file_selection)
         self.layout.addLayout(self.server_status)
         self.layout.addWidget(self.filesize_warning)
-        self.layout.addLayout(self.downloads)
+        self.layout.addWidget(self.downloads_layout_container)
         self.layout.addLayout(self.options)
         central_widget = QtWidgets.QWidget()
         central_widget.setLayout(self.layout)
@@ -210,7 +219,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 events.append(r)
             except web.queue.Empty:
                 done = True
-
+        self.vbar.setValue(self.vbar.maximum())
         for event in events:
             if event["type"] == web.REQUEST_LOAD:
                 self.status_bar.showMessage(strings._('download_page_loaded', True))


### PR DESCRIPTION
Implement solution to issue #297 
- added QGroupBox layout downloads_layout
- added QScrollArea downloads_layout_container
- added instance variable new_download
- automatically scroll through log when new download is  added
