### PR TITLE
added progress bar for zipping files

### DIFF
--- a/onionshare/helpers.py
+++ b/onionshare/helpers.py
@@ -176,19 +176,26 @@ class ZipWriter(object):
     with. If a zip_filename is not passed in, it will use the default onionshare
     filename.
     """
-    def __init__(self, zip_filename=None):
+    def __init__(self, zip_filename=None, processed_size_callback=None):
         if zip_filename:
             self.zip_filename = zip_filename
         else:
             self.zip_filename = '{0:s}/onionshare_{1:s}.zip'.format(tempfile.mkdtemp(), random_string(4, 6))
 
         self.z = zipfile.ZipFile(self.zip_filename, 'w', allowZip64=True)
+        self.processed_size_callback = processed_size_callback
+        if self.processed_size_callback is None:
+            self.processed_size_callback = lambda _: None
+        self._size = 0
+        self.processed_size_callback(self._size)
 
     def add_file(self, filename):
         """
         Add a file to the zip archive.
         """
         self.z.write(filename, os.path.basename(filename), zipfile.ZIP_DEFLATED)
+        self._size += os.path.getsize(filename)
+        self.processed_size_callback(self._size)
 
     def add_dir(self, filename):
         """
@@ -201,6 +208,8 @@ class ZipWriter(object):
                 if not os.path.islink(full_filename):
                     arc_filename = full_filename[len(dir_to_strip):]
                     self.z.write(full_filename, arc_filename, zipfile.ZIP_DEFLATED)
+                    self._size += os.path.getsize(full_filename)
+                    self.processed_size_callback(self._size)
 
     def close(self):
         """

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -31,7 +31,7 @@ zip_filename = None
 zip_filesize = None
 
 
-def set_file_info(filenames):
+def set_file_info(filenames, processed_size_callback=None):
     """
     Using the list of filenames being shared, fill in details that the web
     page will need to display. This includes zipping up the file in order to
@@ -58,7 +58,7 @@ def set_file_info(filenames):
     file_info['dirs'] = sorted(file_info['dirs'], key=lambda k: k['basename'])
 
     # zip up the files and folders
-    z = helpers.ZipWriter()
+    z = helpers.ZipWriter(processed_size_callback=processed_size_callback)
     for info in file_info['files']:
         z.add_file(info['filename'])
     for info in file_info['dirs']:

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -168,20 +168,19 @@ class OnionShareGui(QtWidgets.QMainWindow):
         t.daemon = True
         t.start()
 
+        # add progress bar to the status bar, indicating the crunching of files.
         self._zip_progress_bar = ZipProgressBar(0)
+        self._zip_progress_bar.total_files_size = OnionShareGui._compute_total_size(
+            self.file_selection.file_list.filenames)
         self.status_bar.clearMessage()
         self.status_bar.insertWidget(0, self._zip_progress_bar)
 
         # prepare the files for sending in a new thread
         def finish_starting_server(self):
-            # prepare files to share
-            progress_bar = self._zip_progress_bar
-            progress_bar.total_files_size = OnionShareGui._compute_total_size(
-                self.file_selection.file_list.filenames)
-
             def _set_processed_size(x):
-                progress_bar.processed_size = x
+                self._zip_progress_bar.processed_size = x
 
+            # prepare files to share
             web.set_file_info(self.file_selection.file_list.filenames, processed_size_callback=_set_processed_size)
 
             self.app.cleanup_filenames.append(web.zip_filename)

--- a/resources/locale/cs.json
+++ b/resources/locale/cs.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Prosím čekejte...",
     "error_hs_dir_cannot_create": "Nejde vytvořit složka {0:s} pro hidden service",
     "error_hs_dir_not_writable": "Nejde zapisovat do složky {0:s} pro hidden service",
-    "using_ephemeral": "Staring ephemeral Tor hidden service and awaiting publication"
+    "using_ephemeral": "Staring ephemeral Tor hidden service and awaiting publication",
+    "zip_progress_bar_format": "Crunching files: %p%"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -49,5 +49,6 @@
     "gui_quit_warning": "Are you sure you want to quit?\nThe URL you are sharing won't exist anymore.",
     "gui_quit_warning_quit": "Quit",
     "gui_quit_warning_dont_quit": "Don't Quit",
-    "error_rate_limit": "An attacker might be trying to guess your URL. To prevent this, OnionShare has automatically stopped the server. To share the files you must start it again and share the new URL."
+    "error_rate_limit": "An attacker might be trying to guess your URL. To prevent this, OnionShare has automatically stopped the server. To share the files you must start it again and share the new URL.",
+    "zip_progress_bar_format": "Crunching files: %p%"
 }

--- a/resources/locale/eo.json
+++ b/resources/locale/eo.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Bonvolu atendi...",
     "error_hs_dir_cannot_create": "Ne eblas krei hidden-service-dosierujon {0:s}",
     "error_hs_dir_not_writable": "Ne eblas konservi dosierojn en hidden-service-dosierujo {0:s}",
-    "using_ephemeral": "Staring ephemeral Tor hidden service and awaiting publication"
+    "using_ephemeral": "Staring ephemeral Tor hidden service and awaiting publication",
+    "zip_progress_bar_format": "Crunching files: %p%"
 }

--- a/resources/locale/fi.json
+++ b/resources/locale/fi.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Odota...",
     "error_hs_dir_cannot_create": "Piilopalvelulle ei pystytty luomaan hakemistoa {0:s}",
     "error_hs_dir_not_writable": "Piilopalvelun hakemistoon {0:s} ei voi kirjoittaa",
-    "using_ephemeral": "Käynnistetään lyhytaikainen Tor piilopalvelu ja odotetaan julkaisua"
+    "using_ephemeral": "Käynnistetään lyhytaikainen Tor piilopalvelu ja odotetaan julkaisua",
+    "zip_progress_bar_format": "Tiivistän tiedostoja: %p%"
 }

--- a/resources/locale/it.json
+++ b/resources/locale/it.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Attendere prego...",
     "error_hs_dir_cannot_create": "Impossibile create la cartella per il servizio nascosto {0:s}",
     "error_hs_dir_not_writable": "La cartella per il servizio nascosto {0:s} non ha i permessi di scrittura",
-    "using_ephemeral": "Avviamento del servizio nascosto Tor ephemeral e attesa della pubblicazione"
+    "using_ephemeral": "Avviamento del servizio nascosto Tor ephemeral e attesa della pubblicazione",
+    "zip_progress_bar_format": "Elaborazione files: %p%"
 }

--- a/resources/locale/nl.json
+++ b/resources/locale/nl.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Moment geduld...",
     "error_hs_dir_cannot_create": "Kan verborgen service map {0:s} niet aanmaken",
     "error_hs_dir_not_writable": "Verborgen service map {0:s} is niet schrijfbaar",
-    "using_ephemeral": "Kortstondige Tor hidden service gestart en in afwachting van publicatie"
+    "using_ephemeral": "Kortstondige Tor hidden service gestart en in afwachting van publicatie",
+    "zip_progress_bar_format": "Bestanden verwerken: %p%"
 }

--- a/resources/locale/tr.json
+++ b/resources/locale/tr.json
@@ -41,5 +41,6 @@
     "gui_please_wait": "Lütfen bekleyin...",
     "error_hs_dir_cannot_create": "Gizli hizmet klasörü {0:s} oluşturulamıyor",
     "error_hs_dir_not_writable": "Gizle hizmet klasörü {0:s} yazılabilir değil",
-    "using_ephemeral": "Geçici Tor gizli hizmetine bakılıyor ve yayımı bekleniyor"
+    "using_ephemeral": "Geçici Tor gizli hizmetine bakılıyor ve yayımı bekleniyor",
+    "zip_progress_bar_format": "Dosyalar hazırlanıyor: %p%"
 }


### PR DESCRIPTION
Hi,
I have added progress bar for zipping files, as previously onionshare-gui is showing a message "Crunching files" in the status bar, the progress bar is also shown in the status bar.

this should close #191

PS: I'm attaching a small video - gif demonstrating the results

![ezgif-4163113453](https://cloud.githubusercontent.com/assets/6435796/17908758/4f3a0684-699f-11e6-88f9-8163232bc93f.gif)
