### PR TITLE
Import adjustment

### DIFF
--- a/install/scripts/onionshare
+++ b/install/scripts/onionshare
@@ -18,5 +18,24 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import onionshare
+try:
+    # try to use module installed on system first
+    import onionshare
+except ImportError:
+    # use module provided by source repository
+    import os, sys, inspect
+    # path used to call the executable
+    relative_exec_path = inspect.getfile(inspect.currentframe())
+    # split off path to executable
+    path_to_executable = os.path.split(relative_exec_path)[0]
+    # make sure no symlinks fool the procedure
+    real_path = os.path.realpath(os.path.abspath(path_to_executable))
+    # strip out the install/scripts part
+    module_folder = path_to_executable.replace('/install/scripts', '')
+    # insert module into path
+    if module_folder not in sys.path:
+        sys.path.insert(0, module_folder)
+    # try importing again
+    import onionshare
+
 onionshare.main()

--- a/install/scripts/onionshare-gui
+++ b/install/scripts/onionshare-gui
@@ -18,5 +18,24 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import onionshare_gui
+try:
+    # try to use module installed on system first
+    import onionshare_gui
+except ImportError:
+    # use module provided by source repository
+    import os, sys, inspect
+    # path used to call the executable
+    relative_exec_path = inspect.getfile(inspect.currentframe())
+    # split off path to executable
+    path_to_executable = os.path.split(relative_exec_path)[0]
+    # make sure no symlinks fool the procedure
+    real_path = os.path.realpath(os.path.abspath(path_to_executable))
+    # strip out the install/scripts part
+    module_folder = path_to_executable.replace('/install/scripts', '')
+    # insert module into path
+    if module_folder not in sys.path:
+        sys.path.insert(0, module_folder)
+    # try importing again
+    import onionshare_gui
+
 onionshare_gui.main()


### PR DESCRIPTION
Hi micahflee,

executing the scripts fails if you follow the BUILD.md instructions due to missing modules.

``` sh
$ ./install/scripts/onionshare
Traceback (most recent call last):
  File "./install/scripts/onionshare", line 21, in <module>
    import onionshare
ImportError: No module named 'onionshare'
```

My changes adjust the import path to enable the user to run both the CLI and the GUI version of OnionShare as described.
Cheers,
tpltnt
