### PR TITLE
Fix issue #324, crash when tor is closed first and then onionshare is closed

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -179,7 +179,10 @@ class Onion(object):
         if self.supports_ephemeral:
             # cleanup the ephemeral onion service
             if self.service_id:
-                self.c.remove_ephemeral_hidden_service(self.service_id)
+                try:
+                    self.c.remove_ephemeral_hidden_service(self.service_id)
+                except:
+                    pass
                 self.service_id = None
 
         else:


### PR DESCRIPTION
Fix issue #324, crash when tor is closed first and then onionshare is closed. Worth noting that I did get a repro and confirmed the fix removed the repro, contrary to my earlier comment in the issue.