### PR TITLE
Control port authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,8 @@ If you're interested in exactly what OnionShare does and does not protect agains
 
 ## Quick Start
 
+Check out [the wiki](https://github.com/micahflee/onionshare/wiki) for information about how to use OnionShare and it's various features.
+
 You can download OnionShare to install on your computer from <https://onionshare.org/>.
 
 You can set up your development environment to build OnionShare yourself by following [these instructions](/BUILD.md).
-
-## How to Use
-
-Before you can share files, you need to open [Tor Browser](https://www.torproject.org/) in the background. This will provide the Tor service that OnionShare uses to start the onion service.
-
-Open OnionShare and drag and drop files and folders you wish to share, and click Start Sharing. It will show you a .onion URL such as `http://asxmi4q6i7pajg2b.onion/egg-cain` and copy it to your clipboard. This is the secret URL that can be used to download the file you're sharing. If you'd like multiple people to be able to download this file, uncheck the "close automatically" checkbox.
-
-Send this URL to the person you're trying to send the files to. If the files you're sending aren't secret, you can use normal means of sending the URL: emailing it, posting it to Facebook or Twitter, etc. If you're trying to send secret files then it's important to send this URL securely.
-
-The person who is receiving the files doesn't need OnionShare. All they need is to open the URL you send them in Tor Browser to be able to download the file.
-
-## Using the command line version
-
-In Linux: Just run `onionshare` from the terminal.
-
-In Windows: Add `C:\Program Files (x86)\OnionShare` to your PATH. Now you can run `onionshare.exe` in a command prompt.
-
-In Mac OS X: Run `ln -s /Applications/OnionShare.app/Contents/MacOS/onionshare /usr/local/bin`. Now you can run `onionshare` from the terminal.

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -2,6 +2,8 @@
     "connecting_ctrlport": "Connecting to Tor control port to set up onion service on port {0:d}.",
     "cant_connect_ctrlport": "Can't connect to Tor control port on port {0:s}. OnionShare requires Tor Browser to be running in the background to work. If you don't have it you can get it from https://www.torproject.org/.",
     "cant_connect_socksport": "Can't connect to Tor SOCKS5 server on port {0:s}. OnionShare requires Tor Browser to be running in the background to work. If you don't have it you can get it from https://www.torproject.org/.",
+    "ctrlport_missing_password": "Connected to Tor control port on port {0:s}, but you require a password. You must have the TOR_AUTHENTICATION_PASSWORD environment variable set. Or just open Tor Browser in the background.",
+    "ctrlport_unreadable_cookie": "Connected to Tor control port on port {0:s}, but your user does not have permission to authenticate. You might want to add a HashedControlPassword to your torrc, and set the TOR_AUTHENTICATION_PASSWORD environment variable. Or just open Tor Browser in the background.",
     "preparing_files": "Preparing files to share.",
     "wait_for_hs": "Waiting for HS to be ready:",
     "wait_for_hs_trying": "Trying...",


### PR DESCRIPTION
I've made it so you can specify a Tor control port password using an environment variable, and added instructions to the wiki: https://github.com/micahflee/onionshare/wiki/Using-a-system-tor-instead-of-Tor-Browser

Solves #292.