### PR TITLE
Tor config

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -167,16 +167,14 @@ class Onion(object):
             except UnreadableCookieFile:
                 raise TorErrorUnreadableCookieFile(strings._('settings_error_unreadable_cookie_file'))
 
+        # get the tor version
+        self.tor_version = self.c.get_version().version_str
 
         # do the versions of stem and tor that I'm using support ephemeral onion services?
-        tor_version = self.c.get_version().version_str
         list_ephemeral_hidden_services = getattr(self.c, "list_ephemeral_hidden_services", None)
-        self.supports_ephemeral = callable(list_ephemeral_hidden_services) and tor_version >= '0.2.7.1'
+        self.supports_ephemeral = callable(list_ephemeral_hidden_services) and self.tor_version >= '0.2.7.1'
 
         # do the versions of stem and tor that I'm using support stealth onion services?
-        self.check_for_stealth_support()
-
-    def check_for_stealth_support(self):
         try:
             res = self.c.create_ephemeral_hidden_service({1:1}, basic_auth={'onionshare':None}, await_publication=False)
             tmp_service_id = res.content()[0][2].split('=')[1]

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -58,7 +58,6 @@ class TorErrorUnreadableCookieFile(Exception):
     """
     pass
 
-
 class NoTor(Exception):
     """
     This exception is raised if onionshare can't find a Tor control port

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -25,6 +25,7 @@ import os, sys, tempfile, shutil, urllib
 
 from . import socks
 from . import helpers, strings
+from .settings import Settings
 
 class NoTor(Exception):
     """
@@ -59,6 +60,8 @@ class Onion(object):
     def __init__(self, transparent_torification=False, stealth=False):
         self.transparent_torification = transparent_torification
         self.stealth = stealth
+
+        self.settings = Settings()
 
         # files and dirs to delete on shutdown
         self.cleanup_filenames = []

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -57,11 +57,16 @@ class Onion(object):
     onion services are supported. If not, it falls back to modifying the
     Tor configuration.
     """
-    def __init__(self, transparent_torification=False, stealth=False):
+    def __init__(self, transparent_torification=False, stealth=False, settings=False):
         self.transparent_torification = transparent_torification
         self.stealth = stealth
 
-        self.settings = Settings()
+        # Either use settings that are passed in, or load them from disk
+        if settings:
+            self.settings = settings
+        else:
+            self.settings = Settings()
+            self.settings.load()
 
         # files and dirs to delete on shutdown
         self.cleanup_filenames = []

--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -155,10 +155,11 @@ def main(cwd=None):
         app = OnionShare(debug, local_only, stay_open, transparent_torification, stealth)
         app.choose_port()
         app.start_onion_service()
-    except onion.NoTor as e:
+    except (onion.NoTor, onion.TorTooOld, onion.TorErrorInvalidSetting, onion.TorErrorSocketPort, onion.TorErrorSocketFile, onion.TorErrorMissingPassword, onion.TorErrorUnreadableCookieFile) as e:
         sys.exit(e.args[0])
-    except onion.TorTooOld as e:
-        sys.exit(e.args[0])
+    except KeyboardInterrupt:
+        print("")
+        sys.exit()
 
     # prepare files to share
     print(strings._("preparing_files"))

--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -155,7 +155,7 @@ def main(cwd=None):
         app = OnionShare(debug, local_only, stay_open, transparent_torification, stealth)
         app.choose_port()
         app.start_onion_service()
-    except (onion.NoTor, onion.TorTooOld, onion.TorErrorInvalidSetting, onion.TorErrorSocketPort, onion.TorErrorSocketFile, onion.TorErrorMissingPassword, onion.TorErrorUnreadableCookieFile) as e:
+    except (onion.TorTooOld, onion.TorErrorInvalidSetting, onion.TorErrorAutomatic, onion.TorErrorSocketPort, onion.TorErrorSocketFile, onion.TorErrorMissingPassword, onion.TorErrorUnreadableCookieFile) as e:
         sys.exit(e.args[0])
     except KeyboardInterrupt:
         print("")

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -81,9 +81,6 @@ class Settings(object):
         open(self.filename, 'w').write(json.dumps(self._settings))
 
     def get(self, key):
-        """
-        Set a setting.
-        """
         return self._settings[key]
 
     def set(self, key, val):

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -37,11 +37,10 @@ class Settings(object):
             'version': helpers.get_version(),
             'connection_type': 'automatic',
             'control_port_address': '127.0.0.1',
-            'control_port_port': '9051',
+            'control_port_port': 9051,
             'socket_file_path': '/var/run/tor/control',
             'auth_type': 'no_auth',
-            'auth_password': '',
-            'auth_cookie_path': '/var/run/tor/control.authcookie'
+            'auth_password': ''
         }
 
     def build_filename(self):

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2016 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import platform, os, json
+
+from . import helpers
+
+class Settings(object):
+    """
+    This class stores all of the settings for OnionShare, specifically for how
+    to connect to Tor. If it can't find the settings file, it uses the default,
+    which is to attempt to connect automatically using default Tor Browser
+    settings.
+    """
+    def __init__(self):
+        self.filename = self.build_filename()
+        self.load()
+
+    def build_filename(self):
+        """
+        Returns the path of the settings file.
+        """
+        p = platform.system()
+        if p == 'Windows':
+            appdata = os.environ['APPDATA']
+            return '{}\\OnionShare\\onionshare.json'.format(appdata)
+        elif p == 'Darwin':
+            return os.path.expanduser('~/Library/Application Support/OnionShare/onionshare.json')
+        else:
+            return os.path.expanduser('~/.config/onionshare/onionshare.json')
+
+    def load(self):
+        """
+        Load the settings from file.
+        """
+        default_settings = {
+            'version': helpers.get_version(),
+            'connection_type': 'automatic',
+            'control_port_address': '127.0.0.1',
+            'control_port_port': '9051',
+            'socket_file_path': '/var/run/tor/control',
+            'auth_type': 'no_auth',
+            'auth_password': '',
+            'auth_cookie_path': '/var/run/tor/control.authcookie'
+        }
+
+        if os.path.exists(self.filename):
+            # If the settings file exists, load it
+            try:
+                self._settings = json.loads(open(self.filename, 'r').read())
+            except:
+                # If the settings don't work, use default ones instead
+                self._settings = default_settings
+
+        else:
+            # Otherwise, use default settings
+            self._settings = default_settings
+
+    def save(self):
+        """
+        Save settings to file.
+        """
+        os.mkdirs(os.path.dirname(self.filename))
+        open(self.filename, 'w').write(json.dumps(self._settings))
+
+    def get(self, key):
+        """
+        Set a setting.
+        """
+        return self._settings[key]
+
+    def set(self, key, val):
+        self._settings[key] = val

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -31,7 +31,18 @@ class Settings(object):
     """
     def __init__(self):
         self.filename = self.build_filename()
-        self.load()
+
+        # These are the default settings. They will get overwritten when loading from disk
+        self._settings = {
+            'version': helpers.get_version(),
+            'connection_type': 'automatic',
+            'control_port_address': '127.0.0.1',
+            'control_port_port': '9051',
+            'socket_file_path': '/var/run/tor/control',
+            'auth_type': 'no_auth',
+            'auth_password': '',
+            'auth_cookie_path': '/var/run/tor/control.authcookie'
+        }
 
     def build_filename(self):
         """
@@ -50,28 +61,12 @@ class Settings(object):
         """
         Load the settings from file.
         """
-        default_settings = {
-            'version': helpers.get_version(),
-            'connection_type': 'automatic',
-            'control_port_address': '127.0.0.1',
-            'control_port_port': '9051',
-            'socket_file_path': '/var/run/tor/control',
-            'auth_type': 'no_auth',
-            'auth_password': '',
-            'auth_cookie_path': '/var/run/tor/control.authcookie'
-        }
-
+        # If the settings file exists, load it
         if os.path.exists(self.filename):
-            # If the settings file exists, load it
             try:
                 self._settings = json.loads(open(self.filename, 'r').read())
             except:
-                # If the settings don't work, use default ones instead
-                self._settings = default_settings
-
-        else:
-            # Otherwise, use default settings
-            self._settings = default_settings
+                pass
 
     def save(self):
         """

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import platform, os, json
 
-from . import helpers
+from . import strings, helpers
 
 class Settings(object):
     """
@@ -77,8 +77,12 @@ class Settings(object):
         """
         Save settings to file.
         """
-        os.mkdirs(os.path.dirname(self.filename))
+        try:
+            os.makedirs(os.path.dirname(self.filename))
+        except:
+            pass
         open(self.filename, 'w').write(json.dumps(self._settings))
+        print(strings._('settings_saved').format(self.filename))
 
     def get(self, key):
         return self._settings[key]

--- a/onionshare_gui/alert.py
+++ b/onionshare_gui/alert.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2016 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5 import QtCore, QtWidgets, QtGui
+
+from onionshare import helpers
+
+class Alert(QtWidgets.QMessageBox):
+    """
+    An alert box dialog.
+    """
+    def __init__(self, message, icon=QtWidgets.QMessageBox.NoIcon):
+        super(Alert, self).__init__(None)
+        self.setWindowTitle("OnionShare")
+        self.setWindowIcon(QtGui.QIcon(helpers.get_resource_path('images/logo.png')))
+        self.setText(message)
+        self.setIcon(icon)
+        self.exec_()

--- a/onionshare_gui/menu.py
+++ b/onionshare_gui/menu.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2016 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5 import QtCore, QtWidgets
+
+from onionshare import strings
+
+class Menu(QtWidgets.QMenuBar):
+    """
+    OnionShare's menu bar.
+    """
+    def __init__(self, parent=None):
+        super(Menu, self).__init__(parent)
+
+        file_menu = self.addMenu(strings._('gui_menu_file_menu', True))
+
+        settings_action = file_menu.addAction(strings._('gui_menu_settings_action', True))
+        settings_action.triggered.connect(self.settings)
+        quit_action = file_menu.addAction(strings._('gui_menu_quit_action', True))
+        quit_action.triggered.connect(self.quit)
+
+    def settings(self):
+        """
+        Settings action triggered.
+        """
+        print("Settings clicked")
+
+    def quit(self):
+        """
+        Quit action triggered.
+        """
+        self.parent().qtapp.quit()

--- a/onionshare_gui/menu.py
+++ b/onionshare_gui/menu.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PyQt5 import QtCore, QtWidgets
 
 from onionshare import strings
+from .settings_dialog import SettingsDialog
 
 class Menu(QtWidgets.QMenuBar):
     """
@@ -39,7 +40,7 @@ class Menu(QtWidgets.QMenuBar):
         """
         Settings action triggered.
         """
-        print("Settings clicked")
+        SettingsDialog()
 
     def quit(self):
         """

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -30,7 +30,7 @@ from .file_selection import FileSelection
 from .server_status import ServerStatus
 from .downloads import Downloads
 from .options import Options
-
+from .alert import Alert
 
 class Application(QtWidgets.QApplication):
     """
@@ -238,7 +238,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         """
         If there's an error when trying to start the onion service
         """
-        alert(error, QtWidgets.QMessageBox.Warning)
+        Alert(error, QtWidgets.QMessageBox.Warning)
         self.server_status.stop_server()
         self.status_bar.clearMessage()
 
@@ -298,7 +298,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
             elif event["type"] == web.REQUEST_RATE_LIMIT:
                 self.stop_server()
-                alert(strings._('error_rate_limit'), QtWidgets.QMessageBox.Critical)
+                Alert(strings._('error_rate_limit'), QtWidgets.QMessageBox.Critical)
 
             elif event["type"] == web.REQUEST_PROGRESS:
                 self.downloads.update_download(event["data"]["id"], event["data"]["bytes"])
@@ -396,18 +396,6 @@ class ZipProgressBar(QtWidgets.QProgressBar):
             self.setValue(0)
 
 
-def alert(msg, icon=QtWidgets.QMessageBox.NoIcon):
-    """
-    Pop up a message in a dialog window.
-    """
-    dialog = QtWidgets.QMessageBox()
-    dialog.setWindowTitle("OnionShare")
-    dialog.setWindowIcon(window_icon)
-    dialog.setText(msg)
-    dialog.setIcon(icon)
-    dialog.exec_()
-
-
 def main():
     """
     The main() function implements all of the logic that the GUI version of onionshare uses.
@@ -447,7 +435,7 @@ def main():
         valid = True
         for filename in filenames:
             if not os.path.exists(filename):
-                alert(strings._("not_a_file", True).format(filename))
+                Alert(strings._("not_a_file", True).format(filename))
                 valid = False
         if not valid:
             sys.exit()

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -25,6 +25,7 @@ from PyQt5.QtCore import pyqtSlot
 import onionshare
 from onionshare import strings, helpers, web
 
+from .menu import Menu
 from .file_selection import FileSelection
 from .server_status import ServerStatus
 from .downloads import Downloads
@@ -69,6 +70,9 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         self.setWindowTitle('OnionShare')
         self.setWindowIcon(window_icon)
+
+        # the menu bar
+        self.setMenuBar(Menu())
 
     def send_files(self, filenames=None):
         """

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -177,7 +177,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.app.start_onion_service()
                 self.starting_server_step2.emit()
 
-            except (onionshare.onion.NoTor, onionshare.onion.TorTooOld, onionshare.onion.TorErrorInvalidSetting, onionshare.onion.TorErrorSocketPort, onionshare.onion.TorErrorSocketFile, onionshare.onion.TorErrorMissingPassword, onionshare.onion.TorErrorUnreadableCookieFile) as e:
+            except (onionshare.onion.TorTooOld, onionshare.onion.TorErrorInvalidSetting, onionshare.onion.TorErrorAutomatic, onionshare.onion.TorErrorSocketPort, onionshare.onion.TorErrorSocketFile, onionshare.onion.TorErrorMissingPassword, onionshare.onion.TorErrorUnreadableCookieFile) as e:
                 self.starting_server_error.emit(e.args[0])
                 return
 

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -177,11 +177,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.app.start_onion_service()
                 self.starting_server_step2.emit()
 
-            except onionshare.onion.NoTor as e:
-                self.starting_server_error.emit(e.args[0])
-                return
-
-            except onionshare.onion.TorTooOld as e:
+            except (onionshare.onion.NoTor, onionshare.onion.TorTooOld, onionshare.onion.TorErrorInvalidSetting, onionshare.onion.TorErrorSocketPort, onionshare.onion.TorErrorSocketFile, onionshare.onion.TorErrorMissingPassword, onionshare.onion.TorErrorUnreadableCookieFile) as e:
                 self.starting_server_error.emit(e.args[0])
                 return
 

--- a/onionshare_gui/options.py
+++ b/onionshare_gui/options.py
@@ -43,12 +43,21 @@ class Options(QtWidgets.QVBoxLayout):
         # stealth
         self.stealth = QtWidgets.QCheckBox()
         self.stealth.setCheckState(QtCore.Qt.Unchecked)
-        self.stealth.setText(strings._("create_stealth", True))
+        self.stealth.setText(strings._("gui_create_stealth", True))
         self.stealth.stateChanged.connect(self.stealth_changed)
+
+        # advanced options group
+        advanced_group = QtWidgets.QGroupBox(strings._("gui_advanced_options", True))
+        advanced_group.setCheckable(True)
+        advanced_group.setChecked(False)
+        advanced_group.setFlat(True)
+        advanced_group_layout = QtWidgets.QVBoxLayout()
+        advanced_group_layout.addWidget(self.stealth)
+        advanced_group.setLayout(advanced_group_layout)
 
         # add the widgets
         self.addWidget(self.close_automatically)
-        self.addWidget(self.stealth)
+        self.addWidget(advanced_group)
 
     def stay_open_changed(self, state):
         """

--- a/onionshare_gui/options.py
+++ b/onionshare_gui/options.py
@@ -51,6 +51,7 @@ class Options(QtWidgets.QVBoxLayout):
         advanced_group.setCheckable(True)
         advanced_group.setChecked(False)
         advanced_group.setFlat(True)
+        advanced_group.toggled.connect(self.advanced_options_changed)
         advanced_group_layout = QtWidgets.QVBoxLayout()
         advanced_group_layout.addWidget(self.stealth)
         advanced_group.setLayout(advanced_group_layout)
@@ -63,12 +64,21 @@ class Options(QtWidgets.QVBoxLayout):
         """
         When the 'close automatically' checkbox is toggled, let the web app know.
         """
-        if state > 0:
-            self.web.set_stay_open(False)
-            self.app.stay_open = False
-        else:
+        if state == 0:
             self.web.set_stay_open(True)
             self.app.stay_open = True
+        else:
+            self.web.set_stay_open(False)
+            self.app.stay_open = False
+
+    def advanced_options_changed(self, checked):
+        """
+        When the 'advanced options' checkbox is unchecked, uncheck all advanced
+        options, and let the onionshare app know.
+        """
+        if not checked:
+            self.stealth.setChecked(False)
+            self.app.set_stealth(False)
 
     def stealth_changed(self, state):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -151,7 +151,7 @@ class SettingsDialog(QtWidgets.QDialog):
         if connection_type == 'automatic':
             self.connection_type_automatic_radio.setChecked(True)
         elif connection_type == 'control_port':
-            self.connect_type_control_port_radio.setChecked(True)
+            self.connection_type_control_port_radio.setChecked(True)
         elif connection_type == 'socket_file':
             self.connection_type_socket_file_radio.setChecked(True)
         self.connection_type_control_port_extras_address.setText(self.settings.get('control_port_address'))
@@ -238,7 +238,29 @@ class SettingsDialog(QtWidgets.QDialog):
         """
         Save button clicked. Save current settings to disk.
         """
-        pass
+        if self.connection_type_automatic_radio.isChecked():
+            self.settings.set('connection_type', 'automatic')
+        if self.connection_type_control_port_radio.isChecked():
+            self.settings.set('connection_type', 'control_port')
+        if self.connection_type_socket_file_radio.isChecked():
+            self.settings.set('connection_type', 'socket_file')
+
+        self.settings.set('control_port_address', self.connection_type_control_port_extras_address.text())
+        self.settings.set('control_port_port', self.connection_type_control_port_extras_port.text())
+        self.settings.set('socket_file_path', self.connection_type_socket_file_extras_path.text())
+
+        if self.authenticate_no_auth_radio.isChecked():
+            self.settings.set('auth_type', 'no_auth')
+        if self.authenticate_password_radio.isChecked():
+            self.settings.set('auth_type', 'password')
+        if self.authenticate_cookie_radio.isChecked():
+            self.settings.set('auth_type', 'cookie')
+
+        self.settings.set('auth_password', self.authenticate_password_extras_password.text())
+        self.settings.set('auth_cookie_path', self.authenticate_cookie_extras_cookie_path.text())
+
+        self.settings.save()
+        self.close()
 
     def cancel_clicked(self):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2016 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5 import QtCore, QtWidgets, QtGui
+
+from onionshare import strings
+
+class SettingsDialog(QtWidgets.QDialog):
+    """
+    Settings dialog.
+    """
+    def __init__(self, parent=None):
+        super(SettingsDialog, self).__init__(parent)
+
+        self.setModal(True)
+        self.setWindowTitle(strings._('gui_settings_window_title', True))
+
+        # Connection type: either automatic, control port, or socket file
+
+        # Automatic
+        self.connection_type_automatic_radio = QtWidgets.QRadioButton(strings._('gui_settings_connection_type_automatic_option', True))
+        self.connection_type_automatic_radio.toggled.connect(self.connection_type_automatic_toggled)
+
+        # Control port
+        self.connection_type_control_port_radio = QtWidgets.QRadioButton(strings._('gui_settings_connection_type_control_port_option', True))
+        self.connection_type_control_port_radio.toggled.connect(self.connection_type_control_port_toggled)
+
+        connection_type_control_port_extras_label = QtWidgets.QLabel(strings._('gui_settings_control_port_label', True))
+        self.connection_type_control_port_extras_address = QtWidgets.QLineEdit('127.0.0.1')
+        self.connection_type_control_port_extras_port = QtWidgets.QLineEdit('9051')
+        connection_type_control_port_extras_layout = QtWidgets.QHBoxLayout()
+        connection_type_control_port_extras_layout.addWidget(connection_type_control_port_extras_label)
+        connection_type_control_port_extras_layout.addWidget(self.connection_type_control_port_extras_address)
+        connection_type_control_port_extras_layout.addWidget(self.connection_type_control_port_extras_port)
+
+        self.connection_type_control_port_extras = QtWidgets.QWidget()
+        self.connection_type_control_port_extras.setLayout(connection_type_control_port_extras_layout)
+        self.connection_type_control_port_extras.hide()
+
+        # Socket file
+        self.connection_type_socket_file_radio = QtWidgets.QRadioButton(strings._('gui_settings_connection_type_socket_file_option', True))
+        self.connection_type_socket_file_radio.toggled.connect(self.connection_type_socket_file_toggled)
+
+        connection_type_socket_file_extras_label = QtWidgets.QLabel(strings._('gui_settings_socket_file_label', True))
+        self.connection_type_socket_file_extras_path = QtWidgets.QLineEdit('/var/run/tor/control')
+        connection_type_socket_file_extras_layout = QtWidgets.QHBoxLayout()
+        connection_type_socket_file_extras_layout.addWidget(connection_type_socket_file_extras_label)
+        connection_type_socket_file_extras_layout.addWidget(self.connection_type_socket_file_extras_path)
+
+        self.connection_type_socket_file_extras = QtWidgets.QWidget()
+        self.connection_type_socket_file_extras.setLayout(connection_type_socket_file_extras_layout)
+        self.connection_type_socket_file_extras.hide()
+
+        # Connection type layout
+        connection_type_group_layout = QtWidgets.QVBoxLayout()
+        connection_type_group_layout.addWidget(self.connection_type_automatic_radio)
+        connection_type_group_layout.addWidget(self.connection_type_control_port_radio)
+        connection_type_group_layout.addWidget(self.connection_type_socket_file_radio)
+        connection_type_group_layout.addWidget(self.connection_type_control_port_extras)
+        connection_type_group_layout.addWidget(self.connection_type_socket_file_extras)
+        connection_type_group = QtWidgets.QGroupBox(strings._("gui_settings_connection_type_label", True))
+        connection_type_group.setLayout(connection_type_group_layout)
+
+
+        # Authentication options
+
+        # No authentication
+        self.authenticate_no_auth_radio = QtWidgets.QRadioButton(strings._('gui_settings_authenticate_no_auth_option', True))
+        self.authenticate_no_auth_radio.toggled.connect(self.authenticate_no_auth_toggled)
+
+        # Password
+        self.authenticate_password_radio = QtWidgets.QRadioButton(strings._('gui_settings_authenticate_password_option', True))
+        self.authenticate_password_radio.toggled.connect(self.authenticate_password_toggled)
+
+        authenticate_password_extras_label = QtWidgets.QLabel(strings._('gui_settings_password_label', True))
+        self.authenticate_password_extras_password = QtWidgets.QLineEdit('')
+        authenticate_password_extras_layout = QtWidgets.QHBoxLayout()
+        authenticate_password_extras_layout.addWidget(authenticate_password_extras_label)
+        authenticate_password_extras_layout.addWidget(self.authenticate_password_extras_password)
+
+        self.authenticate_password_extras = QtWidgets.QWidget()
+        self.authenticate_password_extras.setLayout(authenticate_password_extras_layout)
+        self.authenticate_password_extras.hide()
+
+        # Cookie
+        self.authenticate_cookie_radio = QtWidgets.QRadioButton(strings._('gui_settings_authenticate_cookie_option', True))
+        self.authenticate_cookie_radio.toggled.connect(self.authenticate_cookie_toggled)
+
+        authenticate_cookie_extras_label = QtWidgets.QLabel(strings._('gui_settings_cookie_label', True))
+        self.authenticate_cookie_extras_cookie_path = QtWidgets.QLineEdit('/var/run/tor/control.authcookie')
+        authenticate_cookie_extras_layout = QtWidgets.QHBoxLayout()
+        authenticate_cookie_extras_layout.addWidget(authenticate_cookie_extras_label)
+        authenticate_cookie_extras_layout.addWidget(self.authenticate_cookie_extras_cookie_path)
+
+        self.authenticate_cookie_extras = QtWidgets.QWidget()
+        self.authenticate_cookie_extras.setLayout(authenticate_cookie_extras_layout)
+        self.authenticate_cookie_extras.hide()
+
+        # Authentication options layout
+        authenticate_group_layout = QtWidgets.QVBoxLayout()
+        authenticate_group_layout.addWidget(self.authenticate_no_auth_radio)
+        authenticate_group_layout.addWidget(self.authenticate_password_radio)
+        authenticate_group_layout.addWidget(self.authenticate_cookie_radio)
+        authenticate_group_layout.addWidget(self.authenticate_password_extras)
+        authenticate_group_layout.addWidget(self.authenticate_cookie_extras)
+        self.authenticate_group = QtWidgets.QGroupBox(strings._("gui_settings_authenticate_label", True))
+        self.authenticate_group.setLayout(authenticate_group_layout)
+
+
+        # Buttons
+        test_button = QtWidgets.QPushButton(strings._('gui_settings_button_test', True))
+        test_button.clicked.connect(self.test_clicked)
+        save_button = QtWidgets.QPushButton(strings._('gui_settings_button_save', True))
+        save_button.clicked.connect(self.save_clicked)
+        cancel_button = QtWidgets.QPushButton(strings._('gui_settings_button_cancel', True))
+        cancel_button.clicked.connect(self.cancel_clicked)
+        buttons_layout = QtWidgets.QHBoxLayout()
+        buttons_layout.addWidget(test_button)
+        buttons_layout.addWidget(save_button)
+        buttons_layout.addWidget(cancel_button)
+
+        # Layout
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(connection_type_group)
+        layout.addWidget(self.authenticate_group)
+        layout.addStretch()
+        layout.addLayout(buttons_layout)
+        self.setLayout(layout)
+
+        # Set default option
+        self.connection_type_automatic_radio.setChecked(True)
+        self.authenticate_no_auth_radio.setChecked(True)
+
+        # Show the dialog
+        self.exec_()
+
+    def connection_type_automatic_toggled(self, checked):
+        """
+        Connection type automatic was toggled. If checked, disable all other
+        fields. If unchecked, enable all other fields.
+        """
+        if checked:
+            self.authenticate_group.setEnabled(False)
+        else:
+            self.authenticate_group.setEnabled(True)
+
+    def connection_type_control_port_toggled(self, checked):
+        """
+        Connection type control port was toggled. If checked, show extra fields
+        for Tor control address and port. If unchecked, hide those extra fields.
+        """
+        if checked:
+            self.connection_type_control_port_extras.show()
+        else:
+            self.connection_type_control_port_extras.hide()
+
+
+    def connection_type_socket_file_toggled(self, checked):
+        """
+        Connection type socket file was toggled. If checked, show extra fields
+        for socket file. If unchecked, hide those extra fields.
+        """
+        if checked:
+            self.connection_type_socket_file_extras.show()
+        else:
+            self.connection_type_socket_file_extras.hide()
+
+    def authenticate_no_auth_toggled(self, checked):
+        """
+        Authentication option no authentication was toggled.
+        """
+        pass
+
+    def authenticate_password_toggled(self, checked):
+        """
+        Authentication option password was toggled. If checked, show extra fields
+        for password auth. If unchecked, hide those extra fields.
+        """
+        if checked:
+            self.authenticate_password_extras.show()
+        else:
+            self.authenticate_password_extras.hide()
+
+    def authenticate_cookie_toggled(self, checked):
+        """
+        Authentication option cookie was toggled. If checked, show extra fields
+        for cookie auth. If unchecked, hide those extra fields.
+        """
+        if checked:
+            self.authenticate_cookie_extras.show()
+        else:
+            self.authenticate_cookie_extras.hide()
+
+    def test_clicked(self):
+        """
+        Test Settings button clicked. With the given settings, see if we can
+        successfully connect and authenticate to Tor.
+        """
+        pass
+
+    def save_clicked(self):
+        """
+        Save button clicked. Save current settings to disk.
+        """
+        pass
+
+    def cancel_clicked(self):
+        """
+        Cancel button clicked.
+        """
+        self.close()

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -214,9 +214,10 @@ class SettingsDialog(QtWidgets.QDialog):
             onion = Onion(settings=settings)
 
             # If an exception hasn't been raised yet, the Tor settings work
+            Alert(strings._('settings_test_success', True).format(onion.tor_version, onion.supports_ephemeral, onion.supports_stealth))
 
         except (TorErrorInvalidSetting, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile) as e:
-            Alert(e.args[0])
+            Alert(e.args[0], QtWidgets.QMessageBox.Warning)
 
     def save_clicked(self):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -21,7 +21,7 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings
 from onionshare.settings import Settings
-from onionshare.onion import Onion, TorErrorInvalidSetting, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile
+from onionshare.onion import Onion, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile
 
 from .alert import Alert
 
@@ -216,7 +216,7 @@ class SettingsDialog(QtWidgets.QDialog):
             # If an exception hasn't been raised yet, the Tor settings work
             Alert(strings._('settings_test_success', True).format(onion.tor_version, onion.supports_ephemeral, onion.supports_stealth))
 
-        except (TorErrorInvalidSetting, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile) as e:
+        except (TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile) as e:
             Alert(e.args[0], QtWidgets.QMessageBox.Warning)
 
     def save_clicked(self):

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings
+from onionshare.settings import Settings
 
 class SettingsDialog(QtWidgets.QDialog):
     """
@@ -42,8 +43,8 @@ class SettingsDialog(QtWidgets.QDialog):
         self.connection_type_control_port_radio.toggled.connect(self.connection_type_control_port_toggled)
 
         connection_type_control_port_extras_label = QtWidgets.QLabel(strings._('gui_settings_control_port_label', True))
-        self.connection_type_control_port_extras_address = QtWidgets.QLineEdit('127.0.0.1')
-        self.connection_type_control_port_extras_port = QtWidgets.QLineEdit('9051')
+        self.connection_type_control_port_extras_address = QtWidgets.QLineEdit()
+        self.connection_type_control_port_extras_port = QtWidgets.QLineEdit()
         connection_type_control_port_extras_layout = QtWidgets.QHBoxLayout()
         connection_type_control_port_extras_layout.addWidget(connection_type_control_port_extras_label)
         connection_type_control_port_extras_layout.addWidget(self.connection_type_control_port_extras_address)
@@ -58,7 +59,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self.connection_type_socket_file_radio.toggled.connect(self.connection_type_socket_file_toggled)
 
         connection_type_socket_file_extras_label = QtWidgets.QLabel(strings._('gui_settings_socket_file_label', True))
-        self.connection_type_socket_file_extras_path = QtWidgets.QLineEdit('/var/run/tor/control')
+        self.connection_type_socket_file_extras_path = QtWidgets.QLineEdit()
         connection_type_socket_file_extras_layout = QtWidgets.QHBoxLayout()
         connection_type_socket_file_extras_layout.addWidget(connection_type_socket_file_extras_label)
         connection_type_socket_file_extras_layout.addWidget(self.connection_type_socket_file_extras_path)
@@ -103,7 +104,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self.authenticate_cookie_radio.toggled.connect(self.authenticate_cookie_toggled)
 
         authenticate_cookie_extras_label = QtWidgets.QLabel(strings._('gui_settings_cookie_label', True))
-        self.authenticate_cookie_extras_cookie_path = QtWidgets.QLineEdit('/var/run/tor/control.authcookie')
+        self.authenticate_cookie_extras_cookie_path = QtWidgets.QLineEdit()
         authenticate_cookie_extras_layout = QtWidgets.QHBoxLayout()
         authenticate_cookie_extras_layout.addWidget(authenticate_cookie_extras_label)
         authenticate_cookie_extras_layout.addWidget(self.authenticate_cookie_extras_cookie_path)
@@ -143,9 +144,28 @@ class SettingsDialog(QtWidgets.QDialog):
         layout.addLayout(buttons_layout)
         self.setLayout(layout)
 
-        # Set default option
-        self.connection_type_automatic_radio.setChecked(True)
-        self.authenticate_no_auth_radio.setChecked(True)
+
+        # Load settings, and fill them in
+        self.settings = Settings()
+        connection_type = self.settings.get('connection_type')
+        if connection_type == 'automatic':
+            self.connection_type_automatic_radio.setChecked(True)
+        elif connection_type == 'control_port':
+            self.connect_type_control_port_radio.setChecked(True)
+        elif connection_type == 'socket_file':
+            self.connection_type_socket_file_radio.setChecked(True)
+        self.connection_type_control_port_extras_address.setText(self.settings.get('control_port_address'))
+        self.connection_type_control_port_extras_port.setText(self.settings.get('control_port_port'))
+        self.connection_type_socket_file_extras_path.setText(self.settings.get('socket_file_path'))
+        auth_type = self.settings.get('auth_type')
+        if auth_type == 'no_auth':
+            self.authenticate_no_auth_radio.setChecked(True)
+        elif auth_type == 'password':
+            self.authenticate_password_radio.setChecked(True)
+        elif auth_type == 'cookie':
+            self.authenticate_cookie_radio.setChecked(True)
+        self.authenticate_password_extras_password.setText(self.settings.get('auth_password'))
+        self.authenticate_cookie_extras_cookie_path.setText(self.settings.get('auth_cookie_path'))
 
         # Show the dialog
         self.exec_()

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -21,6 +21,7 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings
 from onionshare.settings import Settings
+from onionshare.onion import Onion
 
 class SettingsDialog(QtWidgets.QDialog):
     """
@@ -146,26 +147,28 @@ class SettingsDialog(QtWidgets.QDialog):
 
 
         # Load settings, and fill them in
-        self.settings = Settings()
-        connection_type = self.settings.get('connection_type')
+        settings = Settings()
+        settings.load()
+
+        connection_type = settings.get('connection_type')
         if connection_type == 'automatic':
             self.connection_type_automatic_radio.setChecked(True)
         elif connection_type == 'control_port':
             self.connection_type_control_port_radio.setChecked(True)
         elif connection_type == 'socket_file':
             self.connection_type_socket_file_radio.setChecked(True)
-        self.connection_type_control_port_extras_address.setText(self.settings.get('control_port_address'))
-        self.connection_type_control_port_extras_port.setText(self.settings.get('control_port_port'))
-        self.connection_type_socket_file_extras_path.setText(self.settings.get('socket_file_path'))
-        auth_type = self.settings.get('auth_type')
+        self.connection_type_control_port_extras_address.setText(settings.get('control_port_address'))
+        self.connection_type_control_port_extras_port.setText(settings.get('control_port_port'))
+        self.connection_type_socket_file_extras_path.setText(settings.get('socket_file_path'))
+        auth_type = settings.get('auth_type')
         if auth_type == 'no_auth':
             self.authenticate_no_auth_radio.setChecked(True)
         elif auth_type == 'password':
             self.authenticate_password_radio.setChecked(True)
         elif auth_type == 'cookie':
             self.authenticate_cookie_radio.setChecked(True)
-        self.authenticate_password_extras_password.setText(self.settings.get('auth_password'))
-        self.authenticate_cookie_extras_cookie_path.setText(self.settings.get('auth_cookie_path'))
+        self.authenticate_password_extras_password.setText(settings.get('auth_password'))
+        self.authenticate_cookie_extras_cookie_path.setText(settings.get('auth_cookie_path'))
 
         # Show the dialog
         self.exec_()
@@ -232,34 +235,16 @@ class SettingsDialog(QtWidgets.QDialog):
         Test Settings button clicked. With the given settings, see if we can
         successfully connect and authenticate to Tor.
         """
-        pass
+        print("Testing settings")
+        settings = self.settings_from_fields()
+        onion = Onion(settings=settings)
 
     def save_clicked(self):
         """
         Save button clicked. Save current settings to disk.
         """
-        if self.connection_type_automatic_radio.isChecked():
-            self.settings.set('connection_type', 'automatic')
-        if self.connection_type_control_port_radio.isChecked():
-            self.settings.set('connection_type', 'control_port')
-        if self.connection_type_socket_file_radio.isChecked():
-            self.settings.set('connection_type', 'socket_file')
-
-        self.settings.set('control_port_address', self.connection_type_control_port_extras_address.text())
-        self.settings.set('control_port_port', self.connection_type_control_port_extras_port.text())
-        self.settings.set('socket_file_path', self.connection_type_socket_file_extras_path.text())
-
-        if self.authenticate_no_auth_radio.isChecked():
-            self.settings.set('auth_type', 'no_auth')
-        if self.authenticate_password_radio.isChecked():
-            self.settings.set('auth_type', 'password')
-        if self.authenticate_cookie_radio.isChecked():
-            self.settings.set('auth_type', 'cookie')
-
-        self.settings.set('auth_password', self.authenticate_password_extras_password.text())
-        self.settings.set('auth_cookie_path', self.authenticate_cookie_extras_cookie_path.text())
-
-        self.settings.save()
+        settings = self.settings_from_fields()
+        settings.save()
         self.close()
 
     def cancel_clicked(self):
@@ -267,3 +252,32 @@ class SettingsDialog(QtWidgets.QDialog):
         Cancel button clicked.
         """
         self.close()
+
+    def settings_from_fields(self):
+        """
+        Return a Settings object that's full of values from the settings dialog.
+        """
+        settings = Settings()
+
+        if self.connection_type_automatic_radio.isChecked():
+            settings.set('connection_type', 'automatic')
+        if self.connection_type_control_port_radio.isChecked():
+            settings.set('connection_type', 'control_port')
+        if self.connection_type_socket_file_radio.isChecked():
+            settings.set('connection_type', 'socket_file')
+
+        settings.set('control_port_address', self.connection_type_control_port_extras_address.text())
+        settings.set('control_port_port', self.connection_type_control_port_extras_port.text())
+        settings.set('socket_file_path', self.connection_type_socket_file_extras_path.text())
+
+        if self.authenticate_no_auth_radio.isChecked():
+            settings.set('auth_type', 'no_auth')
+        if self.authenticate_password_radio.isChecked():
+            settings.set('auth_type', 'password')
+        if self.authenticate_cookie_radio.isChecked():
+            settings.set('auth_type', 'cookie')
+
+        settings.set('auth_password', self.authenticate_password_extras_password.text())
+        settings.set('auth_cookie_path', self.authenticate_cookie_extras_cookie_path.text())
+
+        return settings

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -61,5 +61,21 @@
     "gui_create_stealth": "Create stealth onion service",
     "gui_menu_file_menu": "&File",
     "gui_menu_settings_action": "&Settings",
-    "gui_menu_quit_action": "&Quit"
+    "gui_menu_quit_action": "&Quit",
+    "gui_settings_window_title": "Settings",
+    "gui_settings_connection_type_label": "How should OnionShare connect to Tor?",
+    "gui_settings_connection_type_automatic_option": "Attempt automatic configuration with Tor Browser",
+    "gui_settings_connection_type_control_port_option": "Connect using control port",
+    "gui_settings_connection_type_socket_file_option": "Connect using socket file",
+    "gui_settings_control_port_label": "Control port",
+    "gui_settings_socket_file_label": "Socket file",
+    "gui_settings_authenticate_label": "Tor authentication options",
+    "gui_settings_authenticate_no_auth_option": "No authentication",
+    "gui_settings_authenticate_password_option": "Password",
+    "gui_settings_authenticate_cookie_option": "Cookie",
+    "gui_settings_password_label": "Password",
+    "gui_settings_cookie_label": "Cookie path",
+    "gui_settings_button_test": "Test Settings",
+    "gui_settings_button_save": "Save",
+    "gui_settings_button_cancel": "Cancel"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -77,5 +77,6 @@
     "gui_settings_cookie_label": "Cookie path",
     "gui_settings_button_test": "Test Settings",
     "gui_settings_button_save": "Save",
-    "gui_settings_button_cancel": "Cancel"
+    "gui_settings_button_cancel": "Cancel",
+    "settings_saved": "Settings saved to {}"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -56,7 +56,7 @@
     "gui_quit_warning_dont_quit": "Don't Quit",
     "error_rate_limit": "An attacker might be trying to guess your URL. To prevent this, OnionShare has automatically stopped the server. To share the files you must start it again and share the new URL.",
     "zip_progress_bar_format": "Crunching files: %p%",
-    "error_stealth_not_supported": "Your versions of tor or stem are too old. You need to upgrade them to create stealth onion services.",
+    "error_stealth_not_supported": "To create stealth onion services, you need at least Tor 0.2.9.1-alpha (or Tor Browser 6.5) and at least python3-stem 1.5.0.",
     "gui_advanced_options": "Advanced options",
     "gui_create_stealth": "Create stealth onion service"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -1,9 +1,5 @@
 {
     "config_onion_service": "Configuring onion service on port {0:d}.",
-    "cant_connect_ctrlport": "Can't connect to Tor control port on port {0:s}. OnionShare requires Tor Browser to be running in the background to work. If you don't have it you can get it from https://www.torproject.org/.",
-    "cant_connect_socksport": "Can't connect to Tor SOCKS5 server on port {0:s}. OnionShare requires Tor Browser to be running in the background to work. If you don't have it you can get it from https://www.torproject.org/.",
-    "ctrlport_missing_password": "Connected to Tor control port on port {0:s}, but you require a password. You must have the TOR_AUTHENTICATION_PASSWORD environment variable set. Or just open Tor Browser in the background.",
-    "ctrlport_unreadable_cookie": "Connected to Tor control port on port {0:s}, but your user does not have permission to authenticate. You might want to add a HashedControlPassword to your torrc, and set the TOR_AUTHENTICATION_PASSWORD environment variable. Or just open Tor Browser in the background.",
     "preparing_files": "Preparing files to share.",
     "wait_for_hs": "Waiting for HS to be ready:",
     "wait_for_hs_trying": "Trying...",
@@ -80,6 +76,7 @@
     "gui_settings_button_cancel": "Cancel",
     "settings_saved": "Settings saved to {}",
     "settings_error_unknown": "Can't connect to Tor controller because the settings don't make sense.",
+    "settings_error_automatic": "Can't connect to Tor controller. Is Tor Browser running in the background? If you don't have it you can get it from:\nhttps://www.torproject.org/.",
     "settings_error_socket_port": "Can't connect to Tor controller on address {} with port {}.",
     "settings_error_socket_file": "Can't connect to Tor controller using socket file {}.",
     "settings_error_missing_password": "Connected to Tor controller, but it requires a password to authenticate.",

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -83,5 +83,6 @@
     "settings_error_socket_port": "Can't connect to Tor controller on address {} with port {}.",
     "settings_error_socket_file": "Can't connect to Tor controller using socket file {}.",
     "settings_error_missing_password": "Connected to Tor controller, but it requires a password to authenticate.",
-    "settings_error_unreadable_cookie_file": "Connected to Tor controller, but can't authenticate because your password may be wrong, and your user doesn't have permission to read the cookie file."
+    "settings_error_unreadable_cookie_file": "Connected to Tor controller, but can't authenticate because your password may be wrong, and your user doesn't have permission to read the cookie file.",
+    "settings_test_success": "Congratulations, OnionShare can connect to the Tor controller.\n\nTor version: {}\nSupports ephemeral onion services: {}\nSupports stealth onion services: {}"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -57,5 +57,6 @@
     "error_rate_limit": "An attacker might be trying to guess your URL. To prevent this, OnionShare has automatically stopped the server. To share the files you must start it again and share the new URL.",
     "zip_progress_bar_format": "Crunching files: %p%",
     "error_stealth_not_supported": "Your versions of tor or stem are too old. You need to upgrade them to create stealth onion services.",
-    "create_stealth": "Create stealth onion service (advanced)"
+    "gui_advanced_options": "Advanced options",
+    "gui_create_stealth": "Create stealth onion service"
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -70,7 +70,7 @@
     "gui_settings_control_port_label": "Control port",
     "gui_settings_socket_file_label": "Socket file",
     "gui_settings_authenticate_label": "Tor authentication options",
-    "gui_settings_authenticate_no_auth_option": "No authentication",
+    "gui_settings_authenticate_no_auth_option": "No authentication, or cookie authentication",
     "gui_settings_authenticate_password_option": "Password",
     "gui_settings_authenticate_cookie_option": "Cookie",
     "gui_settings_password_label": "Password",
@@ -78,5 +78,10 @@
     "gui_settings_button_test": "Test Settings",
     "gui_settings_button_save": "Save",
     "gui_settings_button_cancel": "Cancel",
-    "settings_saved": "Settings saved to {}"
+    "settings_saved": "Settings saved to {}",
+    "settings_error_unknown": "Can't connect to Tor controller because the settings don't make sense.",
+    "settings_error_socket_port": "Can't connect to Tor controller on address {} with port {}.",
+    "settings_error_socket_file": "Can't connect to Tor controller using socket file {}.",
+    "settings_error_missing_password": "Connected to Tor controller, but it requires a password to authenticate.",
+    "settings_error_unreadable_cookie_file": "Connected to Tor controller, but can't authenticate because your password may be wrong, and your user doesn't have permission to read the cookie file."
 }

--- a/resources/locale/en.json
+++ b/resources/locale/en.json
@@ -58,5 +58,8 @@
     "zip_progress_bar_format": "Crunching files: %p%",
     "error_stealth_not_supported": "To create stealth onion services, you need at least Tor 0.2.9.1-alpha (or Tor Browser 6.5) and at least python3-stem 1.5.0.",
     "gui_advanced_options": "Advanced options",
-    "gui_create_stealth": "Create stealth onion service"
+    "gui_create_stealth": "Create stealth onion service",
+    "gui_menu_file_menu": "&File",
+    "gui_menu_settings_action": "&Settings",
+    "gui_menu_quit_action": "&Quit"
 }


### PR DESCRIPTION
![screenshot_2016-12-29_13-51-29](https://cloud.githubusercontent.com/assets/156128/21555553/f1efee42-cdcd-11e6-96b8-18a8f6cbb4cd.png)

Solves #292. This adds a settings file that stores all the details needed to connect to a Tor controller. The default is to "Attempt automatic configuration with Tor Browser" which is essentially what OnionShare does now (only it's cleaned up some). But using other options, you can easily configure OnionShare to use your system tor with whatever authentication you want now.

Also, the current stable Tor Browser listens on 9151 as the control port, but the current experiment (6.5a6) doesn't seem to listen on this port anymore, and instead OnionShare needs to connect to it using a socket file. So the new "automatic" configuration first tries connecting to the port, and if that fails then it tries connecting to the socket file. NOTE: This still needs more testing in OS X and Windows, and also I'd like to write thorough documentation for using OnionShare with a system tor.