### PR TITLE
Alternative fix for template content injection vulnerability

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import queue, mimetypes, platform, os, sys, socket, logging, html
+import queue, mimetypes, platform, os, sys, socket, logging, re
 from urllib.request import urlopen
 from flask import Flask, Response, request, render_template_string, abort
 
@@ -42,7 +42,7 @@ def set_file_info(filenames, processed_size_callback=None):
     file_info = {'files': [], 'dirs': []}
     for filename in filenames:
         # strips trailing '/' and sanitizes filename
-        basename = html.escape(os.path.basename(filename.rstrip('/')))
+        basename = sanitize_html(os.path.basename(filename.rstrip('/')))
         info = {
             'filename': filename,
             'basename': basename

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import queue, mimetypes, platform, os, sys, socket, logging, re
+import queue, mimetypes, platform, os, sys, socket, logging
 from urllib.request import urlopen
 from flask import Flask, Response, request, render_template_string, abort
 
@@ -41,11 +41,9 @@ def set_file_info(filenames, processed_size_callback=None):
     # build file info list
     file_info = {'files': [], 'dirs': []}
     for filename in filenames:
-        # strips trailing '/' and sanitizes filename
-        basename = sanitize_html(os.path.basename(filename.rstrip('/')))
         info = {
             'filename': filename,
-            'basename': basename
+            'basename': os.path.basename(filename.rstrip('/'))
         }
         if os.path.isfile(filename):
             info['size'] = os.path.getsize(filename)
@@ -55,8 +53,6 @@ def set_file_info(filenames, processed_size_callback=None):
             info['size'] = helpers.dir_size(filename)
             info['size_human'] = helpers.human_readable_filesize(info['size'])
             file_info['dirs'].append(info)
-
-    # sort list of files and directories by basename
     file_info['files'] = sorted(file_info['files'], key=lambda k: k['basename'])
     file_info['dirs'] = sorted(file_info['dirs'], key=lambda k: k['basename'])
 

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -17,11 +17,28 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from distutils.version import StrictVersion as Version
 import queue, mimetypes, platform, os, sys, socket, logging
 from urllib.request import urlopen
+
 from flask import Flask, Response, request, render_template_string, abort
+from flask import __version__ as flask_version
 
 from . import strings, helpers
+
+
+def _safe_select_jinja_autoescape(self, filename):
+    if filename is None:
+        return True
+    return filename.endswith(('.html', '.htm', '.xml', '.xhtml'))
+
+# Starting in Flask 0.11, render_template_string autoescapes template variables
+# by default. To prevent content injection through template variables in
+# earlier versions of Flask, we force autoescaping in the Jinja2 template
+# engine if we detect a Flask version with insecure default behavior.
+if Version(flask_version) < Version('0.11'):
+    # Monkey-patch in the fix from https://github.com/pallets/flask/commit/99c99c4c16b1327288fd76c44bc8635a1de452bc
+    Flask.select_jinja_autoescape = _safe_select_jinja_autoescape
 
 app = Flask(__name__)
 


### PR DESCRIPTION
As I mentioned in my [comment](https://github.com/micahflee/onionshare/issues/319#issuecomment-269794722), I think a better fix for #319 is to fix the insecure default for autoescaping template variables in Flask when rendering templates using the `render_template_string` method. The insecure default was fixed in Flask starting with Flask 0.11, so we only need to fix the behavior in versions of Flask earlier than 0.11.

This PR detects if OnionShare is using an insecure version of Flask, and if so, uses monkeypatching to apply the upstream fix included in versions of Flask >= 0.11. It also reverts the previous attempts to fix this issue.

Unfortunately, it is not easy for me to test this because I do not have ready access to a vulnerable environment (such as Debian Jessie). @micahflee can you test this? If it is too much trouble, let me know, and I will try to find some more of my own free time to test it.

Fixes #319. In addition, this solution prevents **all** content injection in templates rendered using the `render_template_string` method. Since all of OnionShare's templates are HTML templates rendered using `render_template_string`, this is a useful fix that prevents this entire class of content injection vector and is therefore more future-proof than https://github.com/micahflee/onionshare/commit/cff11cd7e48fe4e94ef484ba1f1095362330452d. It also prevents the potential issues with performing HTML auto-escaping in contexts unrelated to rendering HTML, as I discussed in https://github.com/micahflee/onionshare/issues/319#issuecomment-269794722.

Finally, this fix is only necessary if OnionShare can be used with versions of Flask that have insecure defaults for `render_template_string`. In the future, you may require OnionShare use any version of Flask >= 0.11, in which case this code could safely be removed.