### PR TITLE
Whonix support

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -155,7 +155,7 @@ def main(cwd=None):
         app = OnionShare(debug, local_only, stay_open, transparent_torification, stealth)
         app.choose_port()
         app.start_onion_service()
-    except (onion.TorTooOld, onion.TorErrorInvalidSetting, onion.TorErrorAutomatic, onion.TorErrorSocketPort, onion.TorErrorSocketFile, onion.TorErrorMissingPassword, onion.TorErrorUnreadableCookieFile, onion.TorErrorAuthError) as e:
+    except (onion.TorTooOld, onion.TorErrorInvalidSetting, onion.TorErrorAutomatic, onion.TorErrorSocketPort, onion.TorErrorSocketFile, onion.TorErrorMissingPassword, onion.TorErrorUnreadableCookieFile, onion.TorErrorAuthError, onion.TorErrorProtocolError) as e:
         sys.exit(e.args[0])
     except KeyboardInterrupt:
         print("")

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -358,7 +358,14 @@ def start(port, stay_open=False, transparent_torification=False):
 
     set_stay_open(stay_open)
     set_transparent_torification(transparent_torification)
-    app.run(port=port, threaded=True)
+
+    # In Whonix, listen on 0.0.0.0 instead of 127.0.0.1 (#220)
+    if os.path.exists('/usr/share/anon-ws-base-files/workstation'):
+        host = '0.0.0.0'
+    else:
+        host = '127.0.0.1'
+
+    app.run(host=host, port=port, threaded=True)
 
 
 def stop(port):

--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -177,7 +177,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.app.start_onion_service()
                 self.starting_server_step2.emit()
 
-            except (onionshare.onion.TorTooOld, onionshare.onion.TorErrorInvalidSetting, onionshare.onion.TorErrorAutomatic, onionshare.onion.TorErrorSocketPort, onionshare.onion.TorErrorSocketFile, onionshare.onion.TorErrorMissingPassword, onionshare.onion.TorErrorUnreadableCookieFile, onionshare.onion.TorErrorAuthError) as e:
+            except (onionshare.onion.TorTooOld, onionshare.onion.TorErrorInvalidSetting, onionshare.onion.TorErrorAutomatic, onionshare.onion.TorErrorSocketPort, onionshare.onion.TorErrorSocketFile, onionshare.onion.TorErrorMissingPassword, onionshare.onion.TorErrorUnreadableCookieFile, onionshare.onion.TorErrorAuthError, onionshare.onion.TorErrorProtocolError) as e:
                 self.starting_server_error.emit(e.args[0])
                 return
 

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -21,7 +21,7 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings
 from onionshare.settings import Settings
-from onionshare.onion import Onion, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError
+from onionshare.onion import Onion, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError
 
 from .alert import Alert
 
@@ -216,7 +216,7 @@ class SettingsDialog(QtWidgets.QDialog):
             # If an exception hasn't been raised yet, the Tor settings work
             Alert(strings._('settings_test_success', True).format(onion.tor_version, onion.supports_ephemeral, onion.supports_stealth))
 
-        except (TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError) as e:
+        except (TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError) as e:
             Alert(e.args[0], QtWidgets.QMessageBox.Warning)
 
     def save_clicked(self):

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -82,5 +82,6 @@
     "settings_error_auth": "Connected to {}:{}, but can't authenticate. Maybe this isn't a Tor controller?",
     "settings_error_missing_password": "Connected to Tor controller, but it requires a password to authenticate.",
     "settings_error_unreadable_cookie_file": "Connected to Tor controller, but can't authenticate because your password may be wrong, and your user doesn't have permission to read the cookie file.",
-    "settings_test_success": "Congratulations, OnionShare can connect to the Tor controller.\n\nTor version: {}\nSupports ephemeral onion services: {}\nSupports stealth onion services: {}"
+    "settings_test_success": "Congratulations, OnionShare can connect to the Tor controller.\n\nTor version: {}\nSupports ephemeral onion services: {}\nSupports stealth onion services: {}",
+    "error_tor_protocol_error": "Error talking to the Tor controller.\nIf you're using Whonix, check out https://www.whonix.org/wiki/onionshare to make OnionShare work."
 }


### PR DESCRIPTION
Alright, I think that this resolves #344, and also hopefully #220. I haven't tested it though. @adrelanos can you test out this PR in Whonix 14 and let me know if it solves the problems?

I'm going to release version 1.0 very soon, hopefully this weekend, and I'd love to have Whonix support in time. Here's what's in this PR:

* I started catching `stem.ProtocolError` exceptions when starting an onion service and giving an error that tells Whonix users to visit the Whonix wiki. However, I wasn't able to reproduce it. I tried installing OnionShare in Whonix 13, but I couldn't trigger it. Note that in onionshare-gui you can go to File > Settings now to adjust your Tor controller settings.
* If the file `/usr/share/anon-ws-base-files/workstation` exists, the web service listens on 0.0.0.0 instead of 127.0.0.1.