### PR TITLE
#345 - validate the readability of files before adding them

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -67,6 +67,9 @@ def main(cwd=None):
         if not os.path.exists(filename):
             print(strings._("not_a_file").format(filename))
             valid = False
+        if not os.access(filename, os.R_OK):
+            print(strings._("not_a_readable_file").format(filename))
+            valid = False
     if not valid:
         sys.exit()
 

--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import division
 import os, sys, platform, argparse
+from .alert import Alert
 from PyQt5 import QtCore, QtWidgets
 
 from onionshare import strings, common, web
@@ -87,6 +88,9 @@ def main():
         for filename in filenames:
             if not os.path.exists(filename):
                 Alert(strings._("not_a_file", True).format(filename))
+                valid = False
+            if not os.access(filename, os.R_OK):
+                Alert(strings._("not_a_readable_file", True).format(filename))
                 valid = False
         if not valid:
             sys.exit()

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
 from PyQt5 import QtCore, QtWidgets, QtGui
+from .alert import Alert
 
 from onionshare import strings, common
 
@@ -213,7 +214,10 @@ class FileSelection(QtWidgets.QVBoxLayout):
             caption=strings._('gui_choose_files', True), options=QtWidgets.QFileDialog.ReadOnly)
         if filenames:
             for filename in filenames[0]:
-                self.file_list.add_file(filename)
+                if not os.access(filename, os.R_OK):
+                    Alert(strings._("not_a_readable_file", True).format(filename))
+                else:
+                    self.file_list.add_file(filename)
         self.update()
 
     def add_dir(self):

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -9,6 +9,7 @@
     "give_this_url_stealth": "Give this URL and HidServAuth line to the person you're sending the file to:",
     "ctrlc_to_stop":  "Press Ctrl-C to stop server",
     "not_a_file": "{0:s} is not a file.",
+    "not_a_readable_file": "{0:s} is not a readable file.",
     "download_page_loaded": "Download page loaded",
     "other_page_loaded": "URL loaded",
     "closing_automatically": "Closing automatically because download finished",


### PR DESCRIPTION
Should fix #345 in my tests

Also fixes a perhaps previously undiscovered bug in that the onionshare_gui component contained a call to Alert in its validation, however Alert was not defined (imported)