### PR TITLE
Wait a bit longer before attempting to connect to the Tor controller

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -205,7 +205,7 @@ class Onion(object):
                 self.tor_proc = subprocess.Popen([self.tor_path, '-f', self.tor_torrc], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
             # Wait for the tor controller to start
-            time.sleep(0.2)
+            time.sleep(1)
 
             # Connect to the controller
             try:


### PR DESCRIPTION
Seems to fix remaining issue in #385 but will it cover all cases of 'slow computer' (whilst you don't want it to sleep for so long as to be annoying on fast computers)? 