### PR TITLE
Fix double slash in URL of UpdateChecker debug message

### DIFF
--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -97,7 +97,7 @@ class UpdateChecker(QtCore.QObject):
 
                 onion_domain = 'elx57ue5uyfplgva.onion'
 
-                common.log('UpdateChecker', 'check', 'loading http://{}/{}'.format(onion_domain, path))
+                common.log('UpdateChecker', 'check', 'loading http://{}{}'.format(onion_domain, path))
 
                 (socks_address, socks_port) = self.onion.get_tor_socks_port()
                 socks.set_default_proxy(socks.SOCKS5, socks_address, socks_port)


### PR DESCRIPTION
Tiny superficial fix - saw the double slash in the URL in the debug message as per below:

```
[May 19 2017 10:27:04] UpdateChecker.__init__
[May 19 2017 10:27:04] UpdateChecker.check: force=True
[May 19 2017 10:27:04] Settings.__init__
[May 19 2017 10:27:04] Settings.load
[May 19 2017 10:27:04] UpdateChecker.check: checking for updates
[May 19 2017 10:27:04] UpdateChecker.check: loading http://elx57ue5uyfplgva.onion//latest-version.txt?force=1
[May 19 2017 10:27:04] Onion.get_tor_socks_port
[May 19 2017 10:27:12] UpdateChecker.check: latest OnionShare version: 1.0
```