### PR TITLE
387 build script logic fix

### DIFF
--- a/install/build_deb.sh
+++ b/install/build_deb.sh
@@ -12,8 +12,8 @@ rm -r deb_dist >/dev/null 2>&1
 python3 setup.py --command-packages=stdeb.command bdist_deb
 
 # return install instructions if onionshare builds properly
-echo ""
 if [[ $? -eq 0 ]]; then
+	echo ""
 	echo "To install, run:"
 	echo "sudo dpkg -i deb_dist/onionshare_$VERSION-1_all.deb"
 else

--- a/install/build_deb.sh
+++ b/install/build_deb.sh
@@ -21,4 +21,5 @@ if [[ $? -eq 0 ]]; then
 	echo "sudo dpkg -i deb_dist/onionshare_$VERSION-1_all.deb"
 else
 	echo "OnionShare failed to build!"
+	exit 1
 fi

--- a/install/build_deb.sh
+++ b/install/build_deb.sh
@@ -13,6 +13,9 @@ python3 setup.py --command-packages=stdeb.command bdist_deb
 
 # return install instructions if onionshare builds properly
 if [[ $? -eq 0 ]]; then
+	# The build process in stdeb's util.py renames .dev to ~dev
+	# Adjust it here for the purposes of displaying the right filename
+	VERSION="${VERSION/.dev/~dev}"
 	echo ""
 	echo "To install, run:"
 	echo "sudo dpkg -i deb_dist/onionshare_$VERSION-1_all.deb"


### PR DESCRIPTION
stdeb renames .dev to ~dev for compatibility with Debian's strict rules.

This fixes #387 and (in case you like a mystery case closed) I dare say it was probably a similar reason for #176 :)

The alternative would be to ensure you always remember the ~ in share/version.txt but since it's Debian specific (and we're human), and that stdeb already fixes it for you, may as well force-fix it when printing the final filename.

This branch also fixes a separate tiny logic bug - you were checking $? but *after* a whitespace echo, meaning that the script technically never ran your else (exit 1) conditional.