### PR TITLE
More descriptive HTML

### DIFF
--- a/share/html/index.html
+++ b/share/html/index.html
@@ -57,7 +57,9 @@
       .download-size {
         color: #999999;
       }
-
+      .download-description {
+        padding: 10px;
+      }
       .file-list {
         margin: 50px auto 0 auto;
         padding: 10px;
@@ -67,6 +69,7 @@
       .file-list th {
         padding: 5px;
         font-weight: bold;
+        color: #999999;
       }
       .file-list td {
         padding: 5px;
@@ -77,8 +80,14 @@
   </head>
   <body>
     <p><a class="button" href='/{{ slug }}/download'>{{ filename }} &#x25BC;</a></p>
-    <p class="download-size"><strong title="{{ filesize }} bytes">{{ filesize_human }}</strong></p>
+    <p class="download-size"><strong title="{{ filesize }} bytes">{{ filesize_human }} (compressed)</strong></p>
+    <p class="download-description">This zip file contains the following contents:</p>
     <table class="file-list">
+      <tr>
+	<th>Type</th>
+        <th>Name</th>
+        <th>Size</th>
+      </tr>
       {% for info in file_info.dirs %}
       <tr>
         <td><img width="30" height="30" title="" alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAB3RJTUUH3ggbFCQXOpwjbQAAAM5JREFUSMftlksOwyAMRDFCbNjkDL1kz9K75Cq9AZF3kYIM7oqoP/KpcFK1mRUrnsbW2Fbq0N+JiPhZRMS1OZAfzLzocwCAGmC9V2Vhjduarj8CzynGqIwxsDl4SXV267E4uFTN33X8deCxDyV1XXeRYJo1UUDEa9M0pxoRK+b4HiqRcz3nVAJKRK+TSxqaGbrkNKUkBn0oNSK2+T0MA1dau9NzO4QwuvPen1lAxQtEsq/vNpSWhvZ9v/3IRMTWOQezkyuEoKy14tfHoU11A6Mr5AxrpuMVAAAAAElFTkSuQmCC" /></td>


### PR DESCRIPTION
Be explicit that the the first filesize is that of the compressed zip file and that it contains the files beneath. Use the headers in the table that we've styled for

<img width="940" alt="screen shot 2017-05-19 at 3 43 29 pm" src="https://cloud.githubusercontent.com/assets/99173/26281696/a70e6cb0-3e42-11e7-95e6-638d695580f1.png">
