### PR TITLE
Add help button to settings dialog, which takes user to the wiki

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt5 import QtCore, QtWidgets, QtGui
-import sys, platform, datetime
+import os, sys, platform, datetime, webbrowser
 
 from onionshare import strings, common
 from onionshare.settings import Settings
@@ -213,10 +213,13 @@ class SettingsDialog(QtWidgets.QDialog):
         self.save_button.clicked.connect(self.save_clicked)
         self.cancel_button = QtWidgets.QPushButton(strings._('gui_settings_button_cancel', True))
         self.cancel_button.clicked.connect(self.cancel_clicked)
+        self.help_button = QtWidgets.QPushButton(strings._('gui_settings_button_help', True))
+        self.help_button.clicked.connect(self.help_clicked)
         buttons_layout = QtWidgets.QHBoxLayout()
         buttons_layout.addStretch()
         buttons_layout.addWidget(self.save_button)
         buttons_layout.addWidget(self.cancel_button)
+        buttons_layout.addWidget(self.help_button)
 
         # Tor network connection status
         self.tor_status = QtWidgets.QLabel()
@@ -489,6 +492,20 @@ class SettingsDialog(QtWidgets.QDialog):
         """
         common.log('SettingsDialog', 'cancel_clicked')
         self.close()
+
+    def help_clicked(self):
+        """
+        Help button clicked.
+        """
+        common.log('SettingsDialog', 'help_clicked')
+        help_site = 'https://github.com/micahflee/onionshare/wiki'
+        system = platform.system()
+        if system == 'Darwin':
+            # Work around bug in webbrowser on OS X
+            # see http://bugs.python.org/issue30392
+            os.system('open {}'.format(help_site))
+        else:
+            webbrowser.open(help_site)
 
     def settings_from_fields(self):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt5 import QtCore, QtWidgets, QtGui
-import os, sys, platform, datetime, webbrowser
+import sys, platform, datetime
 
 from onionshare import strings, common
 from onionshare.settings import Settings
@@ -499,13 +499,7 @@ class SettingsDialog(QtWidgets.QDialog):
         """
         common.log('SettingsDialog', 'help_clicked')
         help_site = 'https://github.com/micahflee/onionshare/wiki'
-        system = platform.system()
-        if system == 'Darwin':
-            # Work around bug in webbrowser on OS X
-            # see http://bugs.python.org/issue30392
-            os.system('open {}'.format(help_site))
-        else:
-            webbrowser.open(help_site)
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl(help_site))
 
     def settings_from_fields(self):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -216,10 +216,10 @@ class SettingsDialog(QtWidgets.QDialog):
         self.help_button = QtWidgets.QPushButton(strings._('gui_settings_button_help', True))
         self.help_button.clicked.connect(self.help_clicked)
         buttons_layout = QtWidgets.QHBoxLayout()
+        buttons_layout.addWidget(self.help_button)
         buttons_layout.addStretch()
         buttons_layout.addWidget(self.save_button)
         buttons_layout.addWidget(self.cancel_button)
-        buttons_layout.addWidget(self.help_button)
 
         # Tor network connection status
         self.tor_status = QtWidgets.QLabel()

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -81,6 +81,7 @@
     "gui_settings_cookie_label": "Cookie path",
     "gui_settings_button_save": "Save",
     "gui_settings_button_cancel": "Cancel",
+    "gui_settings_button_help": "Help",
     "settings_saved": "Settings saved to {}",
     "settings_error_unknown": "Can't connect to Tor controller because the settings don't make sense.",
     "settings_error_automatic": "Can't connect to Tor controller. Is Tor Browser running in the background? If you don't have it you can get it from:\nhttps://www.torproject.org/.",


### PR DESCRIPTION
There's a slight bug in Python on OS X 10.12.5 that breaks the native webbrowser.open() function. See http://bugs.python.org/issue30392 & https://github.com/jupyter/notebook/issues/2438 for more context.

Using os.system('open ...') works around it - it even opens a new tab in an already-running browser, so it's not bad.

After testing both styles, I thought the Help button looked better for UX on the left, isolated from Save/Cancel... opinions welcome
<img width="681" alt="screen shot 2017-05-20 at 2 03 27 pm" src="https://cloud.githubusercontent.com/assets/99173/26272805/38eb9fb0-3d65-11e7-8a5d-108f0b7839c9.png">


