### PR TITLE
Remove unneeded modules/unreferenced variables as discovered by pyflakes

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -21,9 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from stem.control import Controller
 from stem import ProtocolError, SocketClosed
 from stem.connection import MissingPassword, UnreadableCookieFile, AuthenticationFailure
-import os, sys, tempfile, shutil, urllib, platform, subprocess, time, shlex
+import os, sys, tempfile, platform, subprocess, time, shlex
 
-from . import socks
 from . import common, strings
 from .settings import Settings
 

--- a/onionshare/strings.py
+++ b/onionshare/strings.py
@@ -27,7 +27,6 @@ def load_strings(common, default="en"):
     if the translation does not exist.
     """
     global strings
-    p = common.get_platform()
 
     # find locale dir
     locale_dir = common.get_resource_path('locale')

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from distutils.version import StrictVersion as Version
 import queue, mimetypes, platform, os, sys, socket, logging
-from urllib.request import urlopen
 
 from flask import Flask, Response, request, render_template_string, abort
 from flask import __version__ as flask_version
@@ -219,7 +218,6 @@ def download(slug_candidate):
     # tell GUI the download started
     add_request(REQUEST_DOWNLOAD, path, {'id': download_id})
 
-    dirname = os.path.dirname(zip_filename)
     basename = os.path.basename(zip_filename)
 
     def generate():

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from distutils.version import StrictVersion as Version
 import queue, mimetypes, platform, os, sys, socket, logging
+from urllib.request import urlopen
 
 from flask import Flask, Response, request, render_template_string, abort
 from flask import __version__ as flask_version

--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -25,7 +25,6 @@ from PyQt5 import QtCore, QtWidgets
 from onionshare import strings, common, web
 from onionshare.onion import Onion
 from onionshare.onionshare import OnionShare
-from onionshare.settings import Settings
 
 from .onionshare_gui import OnionShareGui
 

--- a/onionshare_gui/alert.py
+++ b/onionshare_gui/alert.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from PyQt5 import QtCore, QtWidgets, QtGui
+from PyQt5 import QtWidgets, QtGui
 
 from onionshare import common
 

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -17,7 +17,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import platform
 from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings, common

--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -18,13 +18,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt5 import QtCore
-import datetime, time, socket, re, platform
+import datetime, re, platform
 
 from onionshare import socks
 from onionshare.settings import Settings
-from onionshare.onion import Onion
 
-from . import strings, common
+from . import common
 
 class UpdateCheckerCheckError(Exception):
     """

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os, sys, platform, tempfile
+import os, sys
 from distutils.core import setup
 
 def file_list(path):


### PR DESCRIPTION
I ran pyflakes (v1.5.0, as installed with 'pip3 install pyflakes') over the codebase and found a few cases where modules are imported but never used (as well as one or two variables assigned but never used).

Given this cleanup covers a wide number of files, it's probably worth a bit of careful regression testing. Basic test of the app after building on OS X seemed fine for me.