### PR TITLE
Send stay_open variable in the right place, so that it really does stay open

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -221,9 +221,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
             # start onionshare http service in new thread
             # First, load settings and configure
-            settings = Settings()
-            settings.load()
-            self.app.stay_open = not settings.get('close_after_first_download')
+            self.app.stay_open = not self.settings.get('close_after_first_download')
             common.log('OnionShareGUI', 'stay_open', 'stay_open={}'.format(self.app.stay_open))
             t = threading.Thread(target=web.start, args=(self.app.port, self.app.stay_open))
             t.daemon = True

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -203,7 +203,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         settings = Settings()
         settings.load()
         self.app.set_stealth(settings.get('use_stealth'))
-        web.set_stay_open(not settings.get('close_after_first_download'))
 
         # Reset web counters
         web.download_count = 0
@@ -221,6 +220,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 return
 
             # start onionshare http service in new thread
+            # First, load settings and configure
+            settings = Settings()
+            settings.load()
+            self.app.stay_open = not settings.get('close_after_first_download')
+            common.log('OnionShareGUI', 'stay_open', 'stay_open={}'.format(self.app.stay_open))
             t = threading.Thread(target=web.start, args=(self.app.port, self.app.stay_open))
             t.daemon = True
             t.start()


### PR DESCRIPTION
'stay_open' was always evaluating to False, even if we had set it to true in settings. So even if you wanted to stay open, it would still close after the first download.

This turned out to be because it was being set in the wrong place - by the time you start the onionshare http thread, you are sending self.app.stay_open which is still False. 

I verified with some common.log action that even if it was being set to True earlier, it would still be False after the start_server_step2.

```
[May 20 2017 16:13:16] OnionShareWeb.stay_open: stay_open=True
[May 20 2017 16:13:16] OnionShareGui.stay_open: stay_open=True
[May 20 2017 16:13:16] OnionShare.start_onion_service
[May 20 2017 16:13:16] Onion.start_onion_service
Configuring onion service on port 17607.
Starting ephemeral Tor onion service and awaiting publication
[May 20 2017 16:13:52] OnionShareGui.start_server_step2
[May 20 2017 16:13:52] OnionShareWeb.stay_open: stay_open=False
```

This moves the config check to the place where it matters.