### PR TITLE
Reinstate the GUI method of shutting down the web server

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -371,4 +371,7 @@ def stop(port):
         s.connect(('127.0.0.1', port))
         s.sendall('GET /{0:s}/shutdown HTTP/1.1\r\n\r\n'.format(shutdown_slug))
     except:
-        pass
+        try:
+            urlopen('http://127.0.0.1:{0:d}/{1:s}/shutdown'.format(port, shutdown_slug)).read()
+        except:
+            pass


### PR DESCRIPTION
I discovered that clicking 'Stop Sharing' from the UI was not actually stopping the Onion web server! Eek! (First I noticed that a reload of the onion site still loaded in my Tor Browser, and sure enough, lsof confirmed that the port was still open despite the debug message saying it had stopped and cleaned up)

I think the method that allows the GUI to send that request (out of context of the web server environment) was accidentally removed re: removing transparent torification in https://github.com/micahflee/onionshare/commit/bb990ff57484129db26cf43127a58e4e252c9f5f

This reinstates it in the 'except' catch, so that the GUI can still have a method of shutting down the server when we tell it to :)