### PR TITLE
Make it possible to select multiple folders by using non-native QFileDialog

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -225,10 +225,20 @@ class FileSelection(QtWidgets.QVBoxLayout):
         """
         Add folder button clicked.
         """
-        filename = QtWidgets.QFileDialog.getExistingDirectory(
-            caption=strings._('gui_choose_folder', True), options=QtWidgets.QFileDialog.ReadOnly)
-        if filename:
-            self.file_list.add_file(str(filename))
+        file_dialog = QtWidgets.QFileDialog(caption=strings._('gui_choose_folder', True))
+        file_dialog.setFileMode(QtWidgets.QFileDialog.Directory)
+        file_dialog.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
+        file_dialog.setOption(QtWidgets.QFileDialog.ReadOnly, True)
+        file_dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, True)
+        tree_view = file_dialog.findChild(QtWidgets.QTreeView)
+        tree_view.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        list_view = file_dialog.findChild(QtWidgets.QListView, "listView")
+        list_view.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+
+        if file_dialog.exec_() == QtWidgets.QDialog.Accepted:
+          for filename in file_dialog.selectedFiles():
+              self.file_list.add_file(filename)
+
         self.update()
 
     def delete_file(self):

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -27,7 +27,7 @@
     "gui_add_folder": "Add Folders",
     "gui_delete": "Delete",
     "gui_choose_files": "Choose files",
-    "gui_choose_folder": "Choose folder",
+    "gui_choose_folder": "Choose folders",
     "gui_start_server": "Start Sharing",
     "gui_stop_server": "Stop Sharing",
     "gui_copy_url": "Copy URL",

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -24,7 +24,7 @@
     "help_filename": "List of files or folders to share",
     "gui_drag_and_drop": "Drag and drop\nfiles here",
     "gui_add_files": "Add Files",
-    "gui_add_folder": "Add Folder",
+    "gui_add_folder": "Add Folders",
     "gui_delete": "Delete",
     "gui_choose_files": "Choose files",
     "gui_choose_folder": "Choose folder",

--- a/share/locale/fr.json
+++ b/share/locale/fr.json
@@ -24,7 +24,7 @@
     "gui_add_folder": "Ajouter des dossiers",
     "gui_delete": "Supprimer",
     "gui_choose_files": "Sélectionnez des fichiers",
-    "gui_choose_folder": "Sélectionnez un dossier",
+    "gui_choose_folder": "Sélectionnez des dossiers",
     "gui_start_server": "Démarrer le serveur",
     "gui_stop_server": "Arrêter le serveur",
     "gui_copy_url": "Copier URL",

--- a/share/locale/fr.json
+++ b/share/locale/fr.json
@@ -21,7 +21,7 @@
     "help_filename": "Liste des fichiers ou dossiers à partager",
     "gui_drag_and_drop": "Glissez déposez\nles fichiers ici",
     "gui_add_files": "Ajouter des fichiers",
-    "gui_add_folder": "Ajouter un dossier",
+    "gui_add_folder": "Ajouter des dossiers",
     "gui_delete": "Supprimer",
     "gui_choose_files": "Sélectionnez des fichiers",
     "gui_choose_folder": "Sélectionnez un dossier",


### PR DESCRIPTION
To select multiple folders, you need to not use the native dialog. This means the 'Add Folders' dialog is slightly different looking than the file dialog (or we could make that non-native too, for the sake of consistency).

<img width="654" alt="screen shot 2017-05-21 at 4 21 49 pm" src="https://cloud.githubusercontent.com/assets/99173/26281669/b1a97756-3e41-11e7-929e-c8328a268468.png">

The non-native dialog is arguably slightly less 'pretty' (at least on OS X) than the native file dialog, however, it means not having to go through the dialog process each time you want to add a folder, which to me wins in terms of usability. I defer to your best judgment though, just a (working) PoC!

Some locales might need to change to use the plural, I only adjusted the two that I speak.