### PR TITLE
open files via the 'with' statement, to avoid ResourceWarnings on unclosed files

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -94,7 +94,9 @@ def get_version():
     """
     Returns the version of OnionShare that is running.
     """
-    return open(get_resource_path('version.txt')).read().strip()
+    with open(get_resource_path('version.txt')) as f:
+      version = f.read().strip()
+      return version
 
 
 def constant_time_compare(val1, val2):
@@ -133,8 +135,9 @@ def build_slug():
     """
     Returns a random string made from two words from the wordlist, such as "deter-trig".
     """
-    wordlist = open(get_resource_path('wordlist.txt')).read().split('\n')
-    wordlist.remove('')
+    with open(get_resource_path('wordlist.txt')) as f:
+      wordlist = f.read().split('\n')
+      wordlist.remove('')
 
     r = SystemRandom()
     return '-'.join(r.choice(wordlist) for x in range(2))

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -178,7 +178,8 @@ class Onion(object):
                 self.tor_torrc = os.path.join(self.tor_data_directory.name, 'torrc')
             else:
                 # Linux and Mac can use unix sockets
-                torrc_template = open(common.get_resource_path('torrc_template')).read()
+                with open(common.get_resource_path('torrc_template')) as f:
+                  torrc_template = f.read()
                 self.tor_control_port = None
                 self.tor_control_socket = os.path.join(self.tor_data_directory.name, 'control_socket')
                 self.tor_cookie_auth_file = os.path.join(self.tor_data_directory.name, 'cookie')
@@ -192,7 +193,8 @@ class Onion(object):
             torrc_template = torrc_template.replace('{{geo_ip_file}}',      self.tor_geo_ip_file_path)
             torrc_template = torrc_template.replace('{{geo_ipv6_file}}',    self.tor_geo_ipv6_file_path)
             torrc_template = torrc_template.replace('{{socks_port}}',       str(self.tor_socks_port))
-            open(self.tor_torrc, 'w').write(torrc_template)
+            with open(self.tor_torrc, 'w') as f:
+              f.write(torrc_template)
 
             # Execute a tor subprocess
             start_ts = time.time()

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -85,8 +85,9 @@ class Settings(object):
         # If the settings file exists, load it
         if os.path.exists(self.filename):
             try:
-                self._settings = json.loads(open(self.filename, 'r').read())
-                self.fill_in_defaults()
+                with open(self.filename, 'r') as f:
+                  self._settings = json.loads(f.read())
+                  self.fill_in_defaults()
             except:
                 pass
 

--- a/onionshare/strings.py
+++ b/onionshare/strings.py
@@ -38,8 +38,9 @@ def load_strings(common, default="en"):
         abs_filename = os.path.join(locale_dir, filename)
         lang, ext = os.path.splitext(filename)
         if abs_filename.endswith('.json'):
-            lang_json = open(abs_filename, encoding='utf-8').read()
-            translations[lang] = json.loads(lang_json)
+            with open(abs_filename, encoding='utf-8') as f:
+              lang_json = f.read()
+              translations[lang] = json.loads(lang_json)
 
     strings = translations[default]
     lc, enc = locale.getdefaultlocale()


### PR DESCRIPTION
While working on GUI tests, I was getting a lot of these warnings:

```
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/it.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/eo.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/de.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/fi.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/cs.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/fr.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/pt.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/no.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/en.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/tr.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/es.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/ru.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/strings.py:41: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/locale/nl.json' mode='r' encoding='utf-8'>
  lang_json = open(abs_filename, encoding='utf-8').read()
/home/user/onionshare/onionshare/common.py:98: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/version.txt' mode='r' encoding='UTF-8'>
  return open(get_resource_path('version.txt')).read().strip()
/home/user/onionshare/onionshare/settings.py:88: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/.config/onionshare/onionshare.json' mode='r' encoding='UTF-8'>
  self._settings = json.loads(open(self.filename, 'r').read())
/home/user/onionshare/onionshare/onion.py:181: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/user/onionshare/share/torrc_template' mode='r' encoding='UTF-8'>
  torrc_template = open(common.get_resource_path('torrc_template')).read()
/home/user/onionshare/onionshare/onion.py:195: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/tmppv4a7ze_/torrc' mode='w' encoding='UTF-8'>
```

This changes opens the affected files via 'with' so that the close is handled earlier than on full system exit.

Appreciate some extra testing if possible... I adjusted my GUI test at https://gist.github.com/mig5/90986df2d5ec10d60fc9514b5d5ae501 to check the version string is still read properly