### PR TITLE
[WIP] Add a series of basic qTest GUI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfbz"
 install: ""
 # command to run tests
-script
+script:
 - xvfb-run python3 test/onionshare_gui_test.py  | egrep -v "QWidget|QPainter"
 - xvfb-run python3 test/onionshare_settings_test.py  | egrep -v "QWidget|QPainter"
 - nosetests test/onionshare_common_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,4 @@ python:
 before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfb"
 install: ""
 # command to run tests
-script:
-- xvfb-run python3 test/onionshare_gui_test.py  | egrep -v "QWidget|QPainter"
-- xvfb-run python3 test/onionshare_settings_test.py  | egrep -v "QWidget|QPainter"
-- nosetests test/onionshare_common_test.py
-- nosetests test/onionshare_strings_test.py
+script: xvfb-run nosetests3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.7-dev"
   - "nightly"
 # command to install dependencies
-before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfbz"
+before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfb"
 install: ""
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ python:
   - "3.7-dev"
   - "nightly"
 # command to install dependencies
-before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfb"
+before_install:
+- echo "deb http://deb.torproject.org/torproject.org trusty main" | sudo tee -a /etc/apt/sources.list.d/torproject.list
+- gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+- gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+- sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-pyqt5 python3-pip xvfb tor
+- sudo pip3 install stem
 install: ""
 # command to run tests
 script: xvfb-run nosetests3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
 - sudo pip3 install stem
 install: ""
 # command to run tests
-script: xvfb-run nosetests3
+script: ./dev_scripts/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ python:
   - "3.7-dev"
   - "nightly"
 # command to install dependencies
-before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5"
+before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5 xvfbz"
 install: ""
 # command to run tests
-script: nosetests3
+script
+- xvfb-run python3 test/onionshare_gui_test.py  | egrep -v "QWidget|QPainter"
+- xvfb-run python3 test/onionshare_settings_test.py  | egrep -v "QWidget|QPainter"
+- nosetests test/onionshare_common_test.py
+- nosetests test/onionshare_strings_test.py

--- a/dev_scripts/tests
+++ b/dev_scripts/tests
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Designed for Linux for now
+
+if ! xset q &>/dev/null; then
+  # Run via XVFB and silence a lot of noise
+  xvfb-run nosetests3 --exclude=test_starts_with_empty_strings | egrep -v "QPainter|QWidget" | if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; else exit 0; fi
+else
+  nosetests3 --exclude=test_starts_with_empty_strings
+fi

--- a/test/onionshare_auto_shutdown_test.py
+++ b/test/onionshare_auto_shutdown_test.py
@@ -62,6 +62,8 @@ class OnionShareGuiTest(unittest.TestCase):
         # Cheap and nasty request to the .onion to save messing with SOCKS proxies and the like
         self.assertEqual(os.system('torify curl {0:s}'.format(url)), 0)
 
+        QtTest.QTest.qWait(3000)
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         # We should be closed by now. Fail if not!

--- a/test/onionshare_auto_shutdown_test.py
+++ b/test/onionshare_auto_shutdown_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import os, sys, unittest, inspect, socket
+from PyQt5 import QtCore, QtWidgets, QtGui, QtTest
+
+sys.path.append('../onionshare')
+sys.path.append('../onionshare_gui')
+
+setattr(sys, 'onionshare_dev_mode', True)
+
+from onionshare import onion, strings, common
+from onionshare_gui import *
+
+app = QtWidgets.QApplication(sys.argv)
+
+class OnionShareGuiTest(unittest.TestCase):
+    '''Test the OnionShare GUI'''
+    @classmethod
+    def setUpClass(cls):
+        '''Create the GUI'''
+
+        # Create our test file
+        testfile = open('test/test.txt', 'w')
+        testfile.write('onionshare')
+        testfile.close()
+
+        # Start the Onion
+        strings.load_strings(common)
+
+        testonion = onion.Onion()
+        global qtapp
+        qtapp = Application()
+        app = OnionShare(testonion, 0, 0)
+        cls.gui = OnionShareGui(testonion, qtapp, app, ['test/test.txt'])
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Clean up after tests'''
+        os.remove('test/test.txt')
+
+    def test_downloadShare(self):
+        '''
+        Test the following:
+        1. we can start the service by clicking on the start button,
+        2. the server status is now in mode 'working'
+        3. we can't add files to the dialog while working/running
+        4. the server finally completes starting up and is in mode 'running'
+        5. we have a valid onion address in terms of regex and length
+        6. we have a valid web slug
+        7. we can download the zip
+        8. the server stops as soon as we download the zip (assuming config stay_open = False)
+        '''
+        QtTest.QTest.mouseClick(self.gui.server_status.server_button, QtCore.Qt.LeftButton)
+        self.assertEqual(self.gui.server_status.status, 1)
+        self.assertFalse(self.gui.file_selection.add_files_button.isEnabled())
+        QtTest.QTest.qWait(60000)
+        self.assertEqual(self.gui.server_status.status, 2)
+        self.assertRegex(self.gui.app.onion_host, r'[a-z2-7].onion')
+        self.assertEqual(len(self.gui.app.onion_host), 22)
+        self.assertRegex(self.gui.server_status.web.slug, r'(\w+)-(\w+)')
+
+        url = 'http://{0:s}/{1:s}/download'.format(self.gui.app.onion_host, self.gui.server_status.web.slug)
+        # Cheap and nasty request to the .onion to save messing with SOCKS proxies and the like
+        self.assertEqual(os.system('torify curl {0:s}'.format(url)), 0)
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # We should be closed by now. Fail if not!
+        self.assertNotEqual(sock.connect_ex(('127.0.0.1',self.gui.app.port)), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/onionshare_gui_test.py
+++ b/test/onionshare_gui_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os, sys, unittest, inspect, time
+from PyQt5 import QtCore, QtWidgets, QtGui, QtTest
+
+sys.path.append('../onionshare')
+sys.path.append('../onionshare_gui')
+
+from onionshare import onion, strings, common
+from onionshare_gui import *
+
+app = QtWidgets.QApplication(sys.argv)
+
+class OnionShareGuiTest(unittest.TestCase):
+    '''Test the OnionShare GUI'''
+    @classmethod
+    def setUpClass(cls):
+        '''Create the GUI'''
+
+        # Create our test file
+        testfile = open('test/test.txt', 'w')
+        testfile.write('onionshare')
+        testfile.close()
+
+        # Start the Onion
+        strings.load_strings(common)
+
+        testonion = onion.Onion()
+        global qtapp
+        qtapp = Application()
+        app = OnionShare(testonion, 0, 0)
+        cls.gui = OnionShareGui(testonion, qtapp, app, ['test/test.txt'])
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Clean up after tests'''
+        os.remove('test/test.txt')
+
+    def test_guiLoaded(self):
+        '''Test that the GUI actually is shown'''
+        self.assertTrue(self.gui.show)
+
+    def test_version(self):
+        '''
+        Test that the version is parsed from common.get_version()
+        and also in the locale-based version string
+        '''
+        self.assertIn(self.gui.settings.default_settings.get('version'), strings._('version_string').format(common.get_version()))
+
+    def test_windowTitle(self):
+        '''Test that the window title is OnionShare'''
+        self.assertEqual(self.gui.windowTitle(), 'OnionShare')
+
+    def test_downloadContainerHidden(self):
+        '''Test that the download container is hidden'''
+        self.assertTrue(self.gui.downloads_container.isHidden())
+
+    def test_settingsButtonEnabled(self):
+        '''Test that the settings button is enabled'''
+        self.assertTrue(self.gui.settings_button.isEnabled())
+
+    def test_server_statusBar(self):
+        '''Test that the status bar is visible'''
+        self.assertTrue(self.gui.status_bar.isVisible())
+
+    def test_fileSelection_hasfile(self):
+        '''Test that the number of files in the list is 1'''
+        self.assertEqual(self.gui.file_selection.get_num_files(), 1)
+
+    def test_startButtonPress(self):
+        '''
+        Test that we can start the service by clicking on the start button,
+        the add_files button is now disabled while the service starts up,
+        and that we can get a valid .onion address and slug returned once 
+        it's ready
+        '''
+        QtTest.QTest.mouseClick(self.gui.server_status.server_button, QtCore.Qt.LeftButton)
+        self.assertEqual(self.gui.server_status.status, 1)
+        self.assertFalse(self.gui.file_selection.add_files_button.isEnabled())
+        time.sleep(60)
+        self.assertRegex(self.gui.app.onion_host, r'[a-z0-9].onion')
+        self.assertRegex(self.gui.server_status.web.slug, r'(\w+)-(\w+)')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/onionshare_gui_test.py
+++ b/test/onionshare_gui_test.py
@@ -5,6 +5,8 @@ from PyQt5 import QtCore, QtWidgets, QtGui, QtTest
 sys.path.append('../onionshare')
 sys.path.append('../onionshare_gui')
 
+setattr(sys, 'onionshare_dev_mode', True)
+
 from onionshare import onion, strings, common
 from onionshare_gui import *
 

--- a/test/onionshare_settings_test.py
+++ b/test/onionshare_settings_test.py
@@ -12,14 +12,12 @@ from onionshare_gui import *
 
 app = QtWidgets.QApplication(sys.argv)
 
-class OnionShareGuiTest(unittest.TestCase):
-    '''Test the OnionShare GUI'''
+class OnionShareSettingsTest(unittest.TestCase):
+    '''Test the OnionShare Settings Dialog'''
     @classmethod
     def setUpClass(cls):
         '''Create the GUI'''
 
-        # Wipe settings
-        os.remove(os.path.expanduser('~/.config/onionshare/onionshare.json'))
         # Start the Onion
         strings.load_strings(common)
 

--- a/test/onionshare_settings_test.py
+++ b/test/onionshare_settings_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import os, sys, unittest, inspect, json
+from PyQt5 import QtCore, QtWidgets, QtGui, QtTest
+
+sys.path.append('../onionshare')
+sys.path.append('../onionshare_gui')
+
+setattr(sys, 'onionshare_dev_mode', True)
+
+from onionshare import onion, strings, common
+from onionshare_gui import *
+
+app = QtWidgets.QApplication(sys.argv)
+
+class OnionShareGuiTest(unittest.TestCase):
+    '''Test the OnionShare GUI'''
+    @classmethod
+    def setUpClass(cls):
+        '''Create the GUI'''
+
+        # Wipe settings
+        os.remove(os.path.expanduser('~/.config/onionshare/onionshare.json'))
+        # Start the Onion
+        strings.load_strings(common)
+
+        testonion = onion.Onion()
+        global qtapp
+        qtapp = Application()
+        app = OnionShare(testonion, 0, 0)
+        cls.gui = onionshare_gui.SettingsDialog(testonion, qtapp)
+
+    def test_guiLoaded(self):
+        '''Test that the GUI actually is shown'''
+        self.assertTrue(self.gui.show)
+
+    def test_settingsButtonPress(self):
+        '''
+        Test that:
+        1. we can unset the stay_open variable,
+        2. that saving the settings dialog writes the correct new setting to the json file,
+        3. that saving the dialog reboots the onion Tor connection
+        '''
+        QtTest.QTest.mouseClick(self.gui.close_after_first_download_checkbox, QtCore.Qt.LeftButton, pos=QtCore.QPoint(2,self.gui.close_after_first_download_checkbox.height()/2))
+        self.assertFalse(self.gui.close_after_first_download_checkbox.isChecked())
+
+        QtTest.QTest.mouseClick(self.gui.save_button, QtCore.Qt.LeftButton)
+        jsondata = open(os.path.expanduser('~/.config/onionshare/onionshare.json')).read()
+        config = json.loads(jsondata)
+        self.assertFalse(config['close_after_first_download'])
+
+        self.assertTrue(self.gui.onion.connected_to_tor)
+         
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This script from #404 is now able to be run from the root of the repo with 

```python3 test/onionshare_gui_test.py```

```
Connecting to the Tor network: 100% - Done
.....Configuring onion service on port 17646.
Starting ephemeral Tor onion service and awaiting publication
 * Running on http://127.0.0.1:17646/
...
----------------------------------------------------------------------
Ran 8 tests in 96.044s

OK
```

It needs more work, I have not been able to make it stop the service and check if the port is still open (e.g a test for #401)

They could also arguably be broken up into individual files if you prefer, but having an easy entry point into running a bunch of tests seems useful for automation. You can apparently 'group' tests with unittest but I haven't looked into it (I learnt everything done here this afternoon :))