### PR TITLE
Minor update to `common.build_slug`

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -136,11 +136,10 @@ def build_slug():
     Returns a random string made from two words from the wordlist, such as "deter-trig".
     """
     with open(get_resource_path('wordlist.txt')) as f:
-        wordlist = f.read().split('\n')
-        wordlist.remove('')
+        wordlist = f.read().split()
 
     r = SystemRandom()
-    return '-'.join(r.choice(wordlist) for x in range(2))
+    return '-'.join(r.choice(wordlist) for _ in range(2))
 
 
 def human_readable_filesize(b):


### PR DESCRIPTION
Removing the `\n` argument allowed me to get rid of `wordlist.remove('')`. I also then renamed the unused variable `x` to `_`.

---
* [str.split(sep=None, maxsplit=-1)](https://docs.python.org/3/library/stdtypes.html?highlight=str.split#str.split)

    > "If sep is not specified or is `None`, a different splitting algorithm is applied: runs of consecutive whitespace are regarded as a single separator, and the result will contain no empty strings at the start or end if the string has leading or trailing whitespace."

    ```python
    >>> 'a\nb\n'.split('\n')
    ['a', 'b', '']
    >>> 'a\nb\n'.split()
    ['a', 'b']

    ```

* https://stackoverflow.com/questions/5893163/what-is-the-purpose-of-the-single-underscore-variable-in-python

    > "3. As a general purpose "throwaway" variable name to indicate that part of a function result is being deliberately ignored"
