### PR TITLE
Minor update to `common.format_seconds`

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -160,30 +160,19 @@ def human_readable_filesize(b):
 
 def format_seconds(seconds):
     """Return a human-readable string of the format 1d2h3m4s"""
-    seconds_in_a_minute = 60
-    seconds_in_an_hour = seconds_in_a_minute * 60
-    seconds_in_a_day = seconds_in_an_hour * 24
-
-    days = math.floor(seconds / seconds_in_a_day)
-
-    hour_seconds = seconds % seconds_in_a_day
-    hours = math.floor(hour_seconds / seconds_in_an_hour)
-
-    minute_seconds = hour_seconds % seconds_in_an_hour
-    minutes = math.floor(minute_seconds / seconds_in_a_minute)
-
-    remaining_seconds = minute_seconds % seconds_in_a_minute
-    seconds = math.ceil(remaining_seconds)
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
 
     human_readable = []
-    if days > 0:
-        human_readable.append("{}d".format(int(days)))
-    if hours > 0:
-        human_readable.append("{}h".format(int(hours)))
-    if minutes > 0:
-        human_readable.append("{}m".format(int(minutes)))
-    if seconds > 0:
-        human_readable.append("{}s".format(int(seconds)))
+    if days:
+        human_readable.append("{}d".format(days))
+    if hours:
+        human_readable.append("{}h".format(hours))
+    if minutes:
+        human_readable.append("{}m".format(minutes))
+    if seconds or not human_readable:
+        human_readable.append("{:.0f}s".format(seconds))
     return ''.join(human_readable)
 
 

--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -166,11 +166,11 @@ def format_seconds(seconds):
 
     human_readable = []
     if days:
-        human_readable.append("{}d".format(days))
+        human_readable.append("{:.0f}d".format(days))
     if hours:
-        human_readable.append("{}h".format(hours))
+        human_readable.append("{:.0f}h".format(hours))
     if minutes:
-        human_readable.append("{}m".format(minutes))
+        human_readable.append("{:.0f}m".format(minutes))
     if seconds or not human_readable:
         human_readable.append("{:.0f}s".format(seconds))
     return ''.join(human_readable)


### PR DESCRIPTION
@micahflee ,

I used `divmod` to declutter and simplify the calculation of days, hours, minutes and seconds. Importing `math` becomes unnecessary (although I didn't remove the `math` import yet though since my other PR #413 rearranges the imports to one line each and I didn't want a merge conflict).

I made one other change. The current implementation of `format_seconds` returns an empty string if `seconds == 0`. Although the odds are quite small of that actually happening, I thought `0s` might fit better with the theme of "human-readable". That is what the extra check in `if seconds or not human_readable` is for.

---
I've actually been writing tests for these last couple functions I've sent PR's for. I didn't want to push them yet since they were using `pytest` specific tests. Example:

```python
@pytest.mark.parametrize('test_input,expected', [
    (0, '0s'),
    (26, '26s'),
    (60, '1m'),
    (1847, '30m47s'),
    (3600, '1h'),
    (16293, '4h31m33s'),
    (86400, '1d'),
    (129674, '1d12h1m14s'),
])
def test_format_seconds(test_input, expected):
    assert common.format_seconds(test_input) == expected

```

Instead of writing one function per test, `parametrize` helps to cut down on verbosity. As you probably know, stacking multiple asserts inside one regular test function has the disadvantage of stopping after the first fail and not running any tests left below it. Also, less helpful error messages.

Anyways, if you approve of using `pytest` then I would gladly send a PR with these types of tests.
