### PR TITLE
Adds Settings and Help menu items to the systray

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -150,6 +150,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
         system = common.get_platform()
 
         menu = QtWidgets.QMenu()
+        settingsAction = menu.addAction(strings._('gui_settings_window_title', True))
+        settingsAction.triggered.connect(self.open_settings)
+        helpAction = menu.addAction(strings._('gui_settings_button_help', True))
+        helpAction.triggered.connect(SettingsDialog.help_clicked)
         exitAction = menu.addAction(strings._('systray_menu_exit', True))
         exitAction.triggered.connect(self.close)
 


### PR DESCRIPTION
The systray looked a little bare to me with just the Quit button. Added a couple more.

Not sure if you are happy with re-using the same locale string for these, rather than create new systray-specific ones. These aren't technically 'buttons' but 'actions'. Let me know, or feel free to reject if this is a pointless idea :) (also wasn't sure about instantiating a new SettingsDialog for the sake of clicking Help - maybe that Help action needs abstracting out of settings altogether and into the main OnionShareGui)