### PR TITLE
Style a prettier progress bar

### DIFF
--- a/onionshare_gui/downloads.py
+++ b/onionshare_gui/downloads.py
@@ -32,14 +32,24 @@ class Download(object):
         self.downloaded_bytes = 0
 
         # make a new progress bar
+        cssStyleData ="""
+        QProgressBar {
+            border: 2px solid grey;
+            border-radius: 5px;
+            text-align: center;
+        }
+
+        QProgressBar::chunk {
+            background: qlineargradient(x1: 0.5, y1: 0, x2: 0.5, y2: 1, stop: 0 #b366ff, stop: 1 #d9b3ff);
+            width: 10px;
+        }"""
         self.progress_bar = QtWidgets.QProgressBar()
         self.progress_bar.setTextVisible(True)
         self.progress_bar.setAlignment(QtCore.Qt.AlignHCenter)
         self.progress_bar.setMinimum(0)
         self.progress_bar.setMaximum(total_bytes)
         self.progress_bar.setValue(0)
-        self.progress_bar.setStyleSheet(
-            "QProgressBar::chunk { background-color: #05B8CC; }")
+        self.progress_bar.setStyleSheet(cssStyleData)
         self.progress_bar.total_bytes = total_bytes
 
         # start at 0

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -471,9 +471,18 @@ class ZipProgressBar(QtWidgets.QProgressBar):
         self.setMinimumWidth(200)
         self.setValue(0)
         self.setFormat(strings._('zip_progress_bar_format'))
-        self.setStyleSheet(
-            "QProgressBar::chunk { background-color: #05B8CC; } "
-        )
+        cssStyleData ="""
+        QProgressBar {
+            border: 2px solid grey;
+            border-radius: 5px;
+            text-align: center;
+        }
+
+        QProgressBar::chunk {
+            background: qlineargradient(x1: 0.5, y1: 0, x2: 0.5, y2: 1, stop: 0 #b366ff, stop: 1 #d9b3ff);
+            width: 10px;
+        }"""
+        self.setStyleSheet(cssStyleData)
 
         self._total_files_size = total_files_size
         self._processed_size = 0

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -467,18 +467,19 @@ class ZipProgressBar(QtWidgets.QProgressBar):
 
     def __init__(self, total_files_size):
         super(ZipProgressBar, self).__init__()
-        self.setMaximumHeight(15)
+        self.setMaximumHeight(20)
         self.setMinimumWidth(200)
         self.setValue(0)
         self.setFormat(strings._('zip_progress_bar_format'))
         cssStyleData ="""
         QProgressBar {
-            border: 2px solid grey;
-            border-radius: 5px;
+            background-color: rgba(255, 255, 255, 0.0) !important;
+            border: 0px;
             text-align: center;
         }
 
         QProgressBar::chunk {
+            border: 0px;
             background: qlineargradient(x1: 0.5, y1: 0, x2: 0.5, y2: 1, stop: 0 #b366ff, stop: 1 #d9b3ff);
             width: 10px;
         }"""

--- a/onionshare_gui/tor_connection_dialog.py
+++ b/onionshare_gui/tor_connection_dialog.py
@@ -43,6 +43,19 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
         self.setModal(True)
         self.setFixedSize(400, 150)
 
+        cssStyleData ="""
+        QProgressBar {
+            border: 2px solid grey;
+            border-radius: 5px;
+            text-align: center;
+        }
+
+        QProgressBar::chunk {
+            background: qlineargradient(x1: 0.5, y1: 0, x2: 0.5, y2: 1, stop: 0 #b366ff, stop: 1 #d9b3ff);
+            width: 10px;
+        }"""
+        self.setStyleSheet(cssStyleData)
+
         # Label
         self.setLabelText(strings._('connecting_to_tor', True))
 

--- a/onionshare_gui/tor_connection_dialog.py
+++ b/onionshare_gui/tor_connection_dialog.py
@@ -43,19 +43,6 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
         self.setModal(True)
         self.setFixedSize(400, 150)
 
-        cssStyleData ="""
-        QProgressBar {
-            border: 2px solid grey;
-            border-radius: 5px;
-            text-align: center;
-        }
-
-        QProgressBar::chunk {
-            background: qlineargradient(x1: 0.5, y1: 0, x2: 0.5, y2: 1, stop: 0 #b366ff, stop: 1 #d9b3ff);
-            width: 10px;
-        }"""
-        self.setStyleSheet(cssStyleData)
-
         # Label
         self.setLabelText(strings._('connecting_to_tor', True))
 


### PR DESCRIPTION
I thought the progress bar could be improved from the matte blue.

I made a purple (Tor inspired) progress bar with a gradient which feels a bit more pleasant. Your feedback welcome. The only thing I wasn't sure about was the implications for colorblind/vision impaired users.

Edited for 'Crunching files' too, but it's a tighter progress bar, doesn't look quite as good, but maybe better to be consistent with this than leave it as it is.

![purpleprogress](https://cloud.githubusercontent.com/assets/99173/26520910/666096de-431f-11e7-85df-84b117999201.png)


Mac OS

<img width="434" alt="screen shot 2017-05-27 at 9 03 39 pm" src="https://cloud.githubusercontent.com/assets/99173/26520966/a1008a64-4320-11e7-9e0e-8817e288dffe.png">


