### PR TITLE
Remove border around items in the QStatusBar

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -101,6 +101,8 @@ class OnionShareGui(QtWidgets.QMainWindow):
         # Status bar
         self.status_bar = QtWidgets.QStatusBar()
         self.status_bar.setSizeGripEnabled(False)
+        self.status_bar.setStyleSheet(
+            "QStatusBar::item { border: 0px; }")
         version_label = QtWidgets.QLabel('v{0:s}'.format(common.get_version()))
         version_label.setStyleSheet('color: #666666')
         self.settings_button = QtWidgets.QPushButton()


### PR DESCRIPTION
On Mac, the version label and Settings cog icon sit neatly in the status bar seamlessly.

On Linux, I noticed that each widget had a border around it, which is much uglier.

This change forces the border to 0px which fixes it on Linux. I checked my Mac and it doesn't seem to change anything.

Not sure about Windows but if it was an issue there, hopefully this fixes it too.

before:
![os_statusbar_border_linux](https://cloud.githubusercontent.com/assets/99173/26520797/bc59a132-431c-11e7-97ef-093b133c808c.png)

after:
![os_statusbar_noborder_linux](https://cloud.githubusercontent.com/assets/99173/26520798/c325d026-431c-11e7-964f-85ce3f6b86d9.png)

the change in icon in top left doesn't seem related to this change (after noticing it, I reverted my change and it was still missing).  Something about focus on startup. Blame Linux/Qubes for this wtf! :)