### PR TITLE
`hmac.compare_digest` instead of `constant_time_compare`?

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -99,26 +99,6 @@ def get_version():
         return version
 
 
-def constant_time_compare(val1, val2):
-    """
-    Returns True if the two strings are equal, False otherwise.
-
-    The time taken is independent of the number of characters that match.
-
-    For the sake of simplicity, this function executes in constant time only
-    when the two strings have the same length. It short-circuits when they
-    have different lengths.
-
-    From: http://www.levigross.com/2014/02/07/constant-time-comparison-functions-in...-python-haskell-clojure-and-java/
-    """
-    if len(val1) != len(val2):
-        return False
-    result = 0
-    for x, y in zip(val1, val2):
-        result |= x ^ y
-    return result == 0
-
-
 def random_string(num_bytes, output_len=None):
     """
     Returns a random string with a specified number of bytes.

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from distutils.version import StrictVersion as Version
-import queue, mimetypes, platform, os, sys, socket, logging
+import queue, mimetypes, platform, os, sys, socket, logging, hmac
 from urllib.request import urlopen
 
 from flask import Flask, Response, request, render_template_string, abort, make_response
@@ -162,7 +162,7 @@ def check_slug_candidate(slug_candidate, slug_compare = None):
     global slug
     if not slug_compare:
         slug_compare = slug
-    if not common.constant_time_compare(slug_compare.encode('ascii'), slug_candidate.encode('ascii')):
+    if not hmac.compare_digest(slug_compare, slug_candidate):
         abort(404)
 
 


### PR DESCRIPTION
@micahflee ,

I noticed [this link](http://www.levigross.com/2014/02/07/constant-time-comparison-functions-in...-python-haskell-clojure-and-java/) inside the function definition of `constant_time_compare` and saw the comment above it mentioning that this function was built-in to Python. Searching the `cpython` repository showed me this function was accessible through `hmac.compare_digest`.

[hmac.compare_digest(a, b)](https://docs.python.org/3.6/library/hmac.html?highlight=compare_digest#hmac.compare_digest)

> Return a == b. This function uses an approach designed to prevent timing analysis by avoiding content-based short circuiting behaviour, making it appropriate for cryptography. a and b must both be of the same type: either str (ASCII only, as e.g. returned by HMAC.hexdigest()), or a bytes-like object.
> 
> Note If a and b are of different lengths, or if an error occurs, a timing attack could theoretically reveal information about the types and lengths of a and b—but not their values.
> 
> New in version 3.3.

The only usage I could find of `constant_time_compare` in `onionshare` was in `web.py` where both `slug_compare` and `slug_candidate` have to be encoded before comparison.

```python
if not common.constant_time_compare(slug_compare.encode('ascii'), slug_candidate.encode('ascii')):
    abort(404)

```

`hmac.compare_digest` seems to be a bit more flexible since you do not have to encode a Python 3 `str` to `bytes` before using it. Also, it seems to be implemented in C which might be faster than a Python version.

```python
>>> import hmac
>>> constant_time_compare(b'bytes', b'bytes')
True
>>> hmac.compare_digest(b'bytes', b'bytes')
True
>>> constant_time_compare('py3 str', 'py3 str')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "<input>", line 17, in constant_time_compare
TypeError: unsupported operand type(s) for ^: 'str' and 'str'
>>> hmac.compare_digest('py3 str', 'py3 str')
True

```

I'm not sure if there is a particular reason not to use `hmac.compare_digest` so I made this PR just in case using a function from the Python standard library was a better option.
