### PR TITLE
Hide the Onion URL behind a 'Reveal' button that can reveal/hide the Reveal URL when toggled

### DIFF
--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -57,17 +57,15 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         server_layout.addWidget(self.server_button)
 
         # url layout
-        url_font = QtGui.QFont()
-        self.url_label = QtWidgets.QLabel()
-        self.url_label.setFont(url_font)
-        self.url_label.setWordWrap(False)
-        self.url_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.reveal_url_button = QtWidgets.QPushButton(strings._('gui_reveal_url', True))
+        self.reveal_url_button.setCheckable(True)
+        self.reveal_url_button.toggled.connect(self.reveal_url_toggled)
         self.copy_url_button = QtWidgets.QPushButton(strings._('gui_copy_url', True))
         self.copy_url_button.clicked.connect(self.copy_url)
         self.copy_hidservauth_button = QtWidgets.QPushButton(strings._('gui_copy_hidservauth', True))
         self.copy_hidservauth_button.clicked.connect(self.copy_hidservauth)
         url_layout = QtWidgets.QHBoxLayout()
-        url_layout.addWidget(self.url_label)
+        url_layout.addWidget(self.reveal_url_button)
         url_layout.addWidget(self.copy_url_button)
         url_layout.addWidget(self.copy_hidservauth_button)
 
@@ -91,8 +89,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
 
         # set the URL fields
         if self.status == self.STATUS_STARTED:
-            self.url_label.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))
-            self.url_label.show()
+            self.reveal_url_button.show()
             self.copy_url_button.show()
 
             if self.app.stealth:
@@ -104,7 +101,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
             p = self.parentWidget()
             p.resize(p.sizeHint())
         else:
-            self.url_label.hide()
+            self.reveal_url_button.hide()
             self.copy_url_button.hide()
             self.copy_hidservauth_button.hide()
 
@@ -162,6 +159,17 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         """
         self.status = self.STATUS_STOPPED
         self.update()
+
+    def reveal_url_toggled(self, checked):
+        """
+        Toggle the 'Reveal URL' button to either
+        show the Onion URL or hide it
+        """
+        common.log('OnionShareGui', 'reveal_url_toggled', 'URL reveal button was clicked')
+        if checked:
+            self.reveal_url_button.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))
+        else:
+            self.reveal_url_button.setText(strings._('gui_reveal_url', True))
 
     def copy_url(self):
         """

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -34,10 +34,13 @@ class ServerStatus(QtWidgets.QVBoxLayout):
     STATUS_STOPPED = 0
     STATUS_WORKING = 1
     STATUS_STARTED = 2
+    URL_CONCEALED = 0
+    URL_REVEALED = 1
 
     def __init__(self, qtapp, app, web, file_selection):
         super(ServerStatus, self).__init__()
         self.status = self.STATUS_STOPPED
+        self.url_shown = self.URL_CONCEALED
 
         self.qtapp = qtapp
         self.app = app
@@ -58,8 +61,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
 
         # url layout
         self.reveal_url_button = QtWidgets.QPushButton(strings._('gui_reveal_url', True))
-        self.reveal_url_button.setCheckable(True)
-        self.reveal_url_button.toggled.connect(self.reveal_url_toggled)
+        self.reveal_url_button.clicked.connect(self.reveal_url_button_clicked)
         self.copy_url_button = QtWidgets.QPushButton(strings._('gui_copy_url', True))
         self.copy_url_button.clicked.connect(self.copy_url)
         self.copy_hidservauth_button = QtWidgets.QPushButton(strings._('gui_copy_hidservauth', True))
@@ -105,7 +107,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
             self.copy_url_button.hide()
             self.copy_hidservauth_button.hide()
 
-        # button
+        # server status button
         if self.file_selection.get_num_files() == 0:
             self.server_button.setEnabled(False)
             self.server_button.setText(strings._('gui_start_server', True))
@@ -119,6 +121,12 @@ class ServerStatus(QtWidgets.QVBoxLayout):
             else:
                 self.server_button.setEnabled(False)
                 self.server_button.setText(strings._('gui_please_wait'))
+
+        # reveal button
+        if self.revealed == self.URL_REVEALED:
+            self.reveal_url_button.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))
+        else:
+            self.reveal_url_button.setText(strings._('gui_reveal_url', True))
 
     def server_button_clicked(self):
         """
@@ -160,16 +168,18 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         self.status = self.STATUS_STOPPED
         self.update()
 
-    def reveal_url_toggled(self, checked):
+    def reveal_url_button_clicked(self):
         """
         Toggle the 'Reveal URL' button to either
         show the Onion URL or hide it
         """
         common.log('OnionShareGui', 'reveal_url_toggled', 'URL reveal button was clicked')
-        if checked:
-            self.reveal_url_button.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))
+        if self.revealed == self.URL_CONCEALED:
+            self.revealed = self.URL_REVEALED
         else:
-            self.reveal_url_button.setText(strings._('gui_reveal_url', True))
+            self.revealed = self.URL_CONCEALED
+
+        self.update()
 
     def copy_url(self):
         """

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -173,11 +173,12 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         Toggle the 'Reveal URL' button to either
         show the Onion URL or hide it
         """
-        common.log('OnionShareGui', 'reveal_url_toggled', 'URL reveal button was clicked')
         if self.url_shown == self.URL_CONCEALED:
             self.url_shown = self.URL_REVEALED
+            common.log('ServerStatus', 'reveal_url_button_clicked', 'URL was revealed over button')
         else:
             self.url_shown = self.URL_CONCEALED
+            common.log('ServerStatus', 'reveal_url_button_clicked', 'URL was concealed behind button')
 
         self.update()
 

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -123,7 +123,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
                 self.server_button.setText(strings._('gui_please_wait'))
 
         # reveal button
-        if self.revealed == self.URL_REVEALED:
+        if self.url_shown == self.URL_REVEALED:
             self.reveal_url_button.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))
         else:
             self.reveal_url_button.setText(strings._('gui_reveal_url', True))
@@ -174,10 +174,10 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         show the Onion URL or hide it
         """
         common.log('OnionShareGui', 'reveal_url_toggled', 'URL reveal button was clicked')
-        if self.revealed == self.URL_CONCEALED:
-            self.revealed = self.URL_REVEALED
+        if self.url_shown == self.URL_CONCEALED:
+            self.url_shown = self.URL_REVEALED
         else:
-            self.revealed = self.URL_CONCEALED
+            self.url_shown = self.URL_CONCEALED
 
         self.update()
 

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -41,6 +41,7 @@
     "gui_copy_hidservauth": "Copy HidServAuth",
     "gui_downloads": "Downloads:",
     "gui_canceled": "Canceled",
+    "gui_reveal_url": "Reveal URL",
     "gui_copied_url": "Copied URL to clipboard",
     "gui_copied_hidservauth": "Copied HidServAuth line to clipboard",
     "gui_starting_server1": "Starting Tor onion service...",


### PR DESCRIPTION
Just an idea.

To avoid risk of passive collection, the Onion URL could be hidden behind a QPushButton which, when toggled, reveals the URL (and hides it again if toggled once more).

This also has the effect of not stretching the window (and the button widgets) automatically (at least, not so dramatically) once the service is ready (I had another tentative change to set a max width on the buttons so they don't get so long, but it's not perfect).

The idea mainly came from working on #427 - once there are only two buttons, that stretch is a bit more obvious, and then I thought perhaps we can hide that quite sensitive URL by default in any case. 

