### PR TITLE
Ensure the self.filenames list is sorted internally.

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -136,6 +136,8 @@ class FileList(QtWidgets.QListWidget):
                 return
 
             self.filenames.append(filename)
+            # Re-sort the list internally
+            self.filenames.sort()
 
             fileinfo = QtCore.QFileInfo(filename)
             basename = os.path.basename(filename.rstrip('/'))


### PR DESCRIPTION
This is important because even though the QListWidget UI is sorted
automatically, the list is not necessarily. Drag-drop events, depending
on the order in which items were highlighted before being dragged,
can result in a different or reversed order (e.g on a Desktop, if you select 5.txt through 1.txt in a vertical list, rather than top-down, the self.filenames list order was 5.txt, 4.txt, 3.txt, 2.txt, 1.txt). This has implications for
popping the list later (e.g on delete events - if you mark 4.txt to be deleted, the row that is actually popped internally is that of 2.txt)

Fixes https://github.com/micahflee/onionshare/issues/428 