### PR TITLE
On a fresh share, delete any download progress bars of previous shares

### DIFF
--- a/onionshare_gui/downloads.py
+++ b/onionshare_gui/downloads.py
@@ -45,6 +45,7 @@ class Download(object):
         }"""
         self.progress_bar = QtWidgets.QProgressBar()
         self.progress_bar.setTextVisible(True)
+        self.progress_bar.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.progress_bar.setAlignment(QtCore.Qt.AlignHCenter)
         self.progress_bar.setMinimum(0)
         self.progress_bar.setMaximum(total_bytes)
@@ -120,3 +121,12 @@ class Downloads(QtWidgets.QWidget):
         Update a download progress bar to show that it has been canceled.
         """
         self.downloads[download_id].cancel()
+
+    def reset_downloads(self):
+        """
+        Reset the downloads back to zero
+        """
+        for download in self.downloads.values():
+            self.layout.removeWidget(download.progress_bar)
+            download.progress_bar.close() # = None
+        self.downloads = {}

--- a/onionshare_gui/downloads.py
+++ b/onionshare_gui/downloads.py
@@ -128,5 +128,5 @@ class Downloads(QtWidgets.QWidget):
         """
         for download in self.downloads.values():
             self.layout.removeWidget(download.progress_bar)
-            download.progress_bar.close() # = None
+            download.progress_bar.close()
         self.downloads = {}

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -94,6 +94,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.downloads_container.setWidget(self.downloads)
         self.downloads_container.setWidgetResizable(True)
         self.downloads_container.setMaximumHeight(200)
+        self.downloads_container.setMinimumHeight(75)
         self.vbar = self.downloads_container.verticalScrollBar()
         self.downloads_container.hide() # downloads start out hidden
         self.new_download = False
@@ -232,6 +233,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.set_server_active(True)
 
         self.app.set_stealth(self.settings.get('use_stealth'))
+
+        # Hide and reset the downloads if we have previously shared
+        self.downloads_container.hide()
+        self.downloads.reset_downloads()
 
         # Reset web counters
         web.download_count = 0


### PR DESCRIPTION
... and re-hide the downloads container

Tentative fix for #433. Best way to test would be to

1) start and download a couple of 'one time' shares (progress bar should 'reset' each time you click Start Sharing)
2) then change settings to 'stay open', share again, download the file a couple times (should expect to see a list of download progress bars)
3) Stop share, and change settings back to 'Close after first download' share
4) Share again (should expect to see that long list of downloads disappear)
5) Download the share (which stops the share, and should see just one progress bar)


The peculiar setMinimumHeight change was necessary to prevent the Download container from getting too squashed after the Copy URL/URL label area gets hidden on stop/start of the share. (On next Share, the download container was 'squashed' beneath that invisible space and non-optimal - you could barely see the new download progress bar). I could not find another workaround and this did the job.

I don't consider this issue a bug but I have to agree with the OP that it's a UX improvement to 'reset' the downloads - it only makes sense to show multiple download progress bars on a 'stay open' share.