### PR TITLE
WIP: 40% overall test coverage of `onionshare.onionshare`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
   - pip install Flask==0.12 stem==1.5.4 pytest-cov coveralls
 # command to run tests
 script: pytest --cov=onionshare test/
-# after_success:
-#   - coveralls
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: required
+# sudo: required
 dist: trusty
 python:
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ python:
 install:
   - pip install Flask==0.12 stem==1.5.4 pytest-cov coveralls
 # command to run tests
-script: pytest test/ --cov test/
-after_success:
-  - coveralls
+script: pytest --cov=onionshare test/
+# after_success:
+#   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ python:
   - "3.7-dev"
   - "nightly"
 # command to install dependencies
-before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5"
-install: ""
+# before_install: "sudo apt-get update; sudo apt-get install -y python3-nose python3-flask python3-stem python3-pyqt5"
+install:
+  - pip install Flask==0.12 stem==1.5.4 pytest-cov coveralls
 # command to run tests
-script: nosetests3
+script: pytest test/ --cov test/
+after_success:
+  - coveralls

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,116 @@
+import os
+import shutil
+import sys
+import tempfile
+
+import pytest
+
+from onionshare import common
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture()
+def temp_dir_1024_delete():
+    """
+    Create a temporary directory that has a single file of a particular
+    size (1024 bytes). The temporary directory (and file inside) will
+    be deleted after fixture usage.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_file, tmp_file_path = tempfile.mkstemp(dir=tmp_dir)
+        with open(tmp_file, 'wb') as f:
+            f.write(b'*' * 1024)
+        yield tmp_dir
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture()
+def temp_file_1024_delete():
+    """
+    Create a temporary file of a particular size (1024 bytes).
+    The temporary file will be deleted after fixture usage.
+    """
+
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file.write(b'*' * 1024)
+        tmp_file.flush()
+        yield tmp_file.name
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture(scope='session')
+def custom_zw():
+    zw = common.ZipWriter(
+        zip_filename=common.random_string(4, 6),
+        processed_size_callback=lambda _: 'custom_callback'
+    )
+    yield zw
+    zw.close()
+    os.remove(zw.zip_filename)
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture(scope='session')
+def default_zw():
+    zw = common.ZipWriter()
+    yield zw
+    zw.close()
+    tmp_dir = os.path.dirname(zw.zip_filename)
+    shutil.rmtree(tmp_dir)
+
+
+@pytest.fixture
+def platform_darwin(monkeypatch):
+    monkeypatch.setattr('platform.system', lambda: 'Darwin')
+
+
+@pytest.fixture
+def platform_linux(monkeypatch):
+    monkeypatch.setattr('platform.system', lambda: 'Linux')
+
+
+@pytest.fixture
+def platform_windows(monkeypatch):
+    monkeypatch.setattr('platform.system', lambda: 'Windows')
+
+
+@pytest.fixture
+def set_debug_false(monkeypatch):
+    monkeypatch.setattr('onionshare.common.debug', False)
+
+
+@pytest.fixture
+def set_debug_true(monkeypatch):
+    monkeypatch.setattr('onionshare.common.debug', True)
+
+
+@pytest.fixture
+def sys_argv_sys_prefix(monkeypatch):
+    monkeypatch.setattr('sys.argv', [sys.prefix])
+
+
+@pytest.fixture
+def sys_frozen(monkeypatch):
+    monkeypatch.setattr('sys.frozen', True, raising=False)
+
+
+@pytest.fixture
+def sys_meipass(monkeypatch):
+    monkeypatch.setattr(
+        'sys._MEIPASS', os.path.expanduser('~'), raising=False)
+
+
+@pytest.fixture
+def sys_onionshare_dev_mode(monkeypatch):
+    monkeypatch.setattr('sys.onionshare_dev_mode', True, raising=False)
+
+
+@pytest.fixture
+def time_time_100(monkeypatch):
+    monkeypatch.setattr('time.time', lambda: 100)
+
+
+@pytest.fixture
+def time_strftime(monkeypatch):
+    monkeypatch.setattr('time.strftime', lambda _: 'Jun 06 2013 11:05:00')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,11 +10,24 @@ from onionshare import common
 
 # pytest > 2.9 only needs @pytest.fixture
 @pytest.yield_fixture()
-def temp_dir_1024_delete():
+def temp_dir_1024():
+    """ Create a temporary directory that has a single file of a
+    particular size (1024 bytes).
     """
-    Create a temporary directory that has a single file of a particular
-    size (1024 bytes). The temporary directory (and file inside) will
-    be deleted after fixture usage.
+
+    tmp_dir = tempfile.mkdtemp()
+    tmp_file, tmp_file_path = tempfile.mkstemp(dir=tmp_dir)
+    with open(tmp_file, 'wb') as f:
+        f.write(b'*' * 1024)
+    yield tmp_dir
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture()
+def temp_dir_1024_delete():
+    """ Create a temporary directory that has a single file of a
+    particular size (1024 bytes). The temporary directory (including
+    the file inside) will be deleted after fixture usage.
     """
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -22,6 +35,16 @@ def temp_dir_1024_delete():
         with open(tmp_file, 'wb') as f:
             f.write(b'*' * 1024)
         yield tmp_dir
+
+
+# pytest > 2.9 only needs @pytest.fixture
+@pytest.yield_fixture()
+def temp_file_1024():
+    """ Create a temporary file of a particular size (1024 bytes). """
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        tmp_file.write(b'*' * 1024)
+    yield tmp_file.name
 
 
 # pytest > 2.9 only needs @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -84,6 +84,26 @@ def default_zw():
 
 
 @pytest.fixture
+def locale_en(monkeypatch):
+    monkeypatch.setattr('locale.getdefaultlocale', lambda: ('en_US', 'UTF-8'))
+
+
+@pytest.fixture
+def locale_fr(monkeypatch):
+    monkeypatch.setattr('locale.getdefaultlocale', lambda: ('fr_FR', 'UTF-8'))
+
+
+@pytest.fixture
+def locale_invalid(monkeypatch):
+    monkeypatch.setattr('locale.getdefaultlocale', lambda: ('xx_XX', 'UTF-8'))
+
+
+@pytest.fixture
+def locale_ru(monkeypatch):
+    monkeypatch.setattr('locale.getdefaultlocale', lambda: ('ru_RU', 'UTF-8'))
+
+
+@pytest.fixture
 def platform_darwin(monkeypatch):
     monkeypatch.setattr('platform.system', lambda: 'Darwin')
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,8 +8,7 @@ import pytest
 from onionshare import common
 
 
-# pytest > 2.9 only needs @pytest.fixture
-@pytest.yield_fixture()
+@pytest.fixture
 def temp_dir_1024():
     """ Create a temporary directory that has a single file of a
     particular size (1024 bytes).
@@ -19,11 +18,11 @@ def temp_dir_1024():
     tmp_file, tmp_file_path = tempfile.mkstemp(dir=tmp_dir)
     with open(tmp_file, 'wb') as f:
         f.write(b'*' * 1024)
-    yield tmp_dir
+    return tmp_dir
 
 
 # pytest > 2.9 only needs @pytest.fixture
-@pytest.yield_fixture()
+@pytest.yield_fixture
 def temp_dir_1024_delete():
     """ Create a temporary directory that has a single file of a
     particular size (1024 bytes). The temporary directory (including
@@ -37,18 +36,17 @@ def temp_dir_1024_delete():
         yield tmp_dir
 
 
-# pytest > 2.9 only needs @pytest.fixture
-@pytest.yield_fixture()
+@pytest.fixture
 def temp_file_1024():
     """ Create a temporary file of a particular size (1024 bytes). """
 
     with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
         tmp_file.write(b'*' * 1024)
-    yield tmp_file.name
+    return tmp_file.name
 
 
 # pytest > 2.9 only needs @pytest.fixture
-@pytest.yield_fixture()
+@pytest.yield_fixture
 def temp_file_1024_delete():
     """
     Create a temporary file of a particular size (1024 bytes).
@@ -108,7 +106,7 @@ def platform_darwin(monkeypatch):
     monkeypatch.setattr('platform.system', lambda: 'Darwin')
 
 
-@pytest.fixture
+@pytest.fixture  # (scope="session")
 def platform_linux(monkeypatch):
     monkeypatch.setattr('platform.system', lambda: 'Linux')
 
@@ -144,7 +142,7 @@ def sys_meipass(monkeypatch):
         'sys._MEIPASS', os.path.expanduser('~'), raising=False)
 
 
-@pytest.fixture
+@pytest.fixture  # (scope="session")
 def sys_onionshare_dev_mode(monkeypatch):
     monkeypatch.setattr('sys.onionshare_dev_mode', True, raising=False)
 

--- a/test/onionshare_common_test.py
+++ b/test/onionshare_common_test.py
@@ -16,20 +16,440 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+
+import contextlib
+import inspect
+import io
+import os
+import platform
+import random
+import re
+import shutil
 import socket
+import sys
+import tempfile
+import time
+import zipfile
+
+import pytest
+
 from onionshare import common
 
+DEFAULT_ZW_FILENAME_REGEX = re.compile(r'^onionshare_[a-z2-7]{6}.zip$')
+# TODO: use re.VERBOSE on LOG_MSG_REGEX for readability?
+LOG_MSG_REGEX = re.compile(r'^\[Jun 06 2013 11:05:00\] TestModule\.<function test_log\.<locals>\.test_func at 0x[a-f0-9]+>(: TEST_MSG)?$')
+RANDOM_STR_REGEX = re.compile(r'^[a-z2-7]+$')
+SLUG_REGEX = re.compile(r'^([a-z]+)(-[a-z]+)?-([a-z]+)(-[a-z]+)?$')
 
-def test_get_platform_returns_platform_system():
-    """get_platform() returns platform.system() when ONIONSHARE_PLATFORM is not defined"""
-    p = common.platform.system
-    common.platform.system = lambda: 'Sega Saturn'
-    assert common.get_platform() == 'Sega Saturn'
-    common.platform.system = p
 
-def test_get_available_port_returns_an_open_port():
-    """get_available_port() should return an open port within the range"""
-    for i in range(100):
-        port = common.get_available_port(1024, 2048)
-        assert 1024 <= port <= 2048
-        socket.socket().bind(("127.0.0.1", port))
+# #################################################
+# FIXTURES
+# #################################################
+
+# TODO: separate fixtures into a separate file?
+# TODO: comment fixtures properly
+
+
+@pytest.fixture(scope='session')
+def custom_zw():
+    # TODO: revert to old style setup/teardown instead of yield
+    zw = common.ZipWriter(zip_filename=common.random_string(4, 6))
+    yield zw
+    zw.close()
+    os.remove(zw.zip_filename)
+
+
+@pytest.fixture(scope='session')
+def default_zw():
+    # TODO: revert to old style setup/teardown instead of yield
+    zw = common.ZipWriter()
+    yield zw
+    zw.close()
+    os.remove(zw.zip_filename)
+
+
+@pytest.fixture
+def platform_darwin(monkeypatch):
+    monkeypatch.setattr(platform, 'system', lambda: 'Darwin')
+
+
+@pytest.fixture
+def platform_linux(monkeypatch):
+    monkeypatch.setattr(platform, 'system', lambda: 'Linux')
+
+
+@pytest.fixture
+def platform_windows(monkeypatch):
+    monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+
+@pytest.fixture
+def sys_argv_sys_prefix(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', [sys.prefix])
+
+
+@pytest.fixture
+def sys_frozen(monkeypatch):
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+
+
+@pytest.fixture
+def sys_meipass(monkeypatch):
+    monkeypatch.setattr(
+        sys, '_MEIPASS', os.path.expanduser('~'), raising=False)
+
+
+@pytest.fixture
+def sys_onionshare_dev_mode(monkeypatch):
+    monkeypatch.setattr(sys, 'onionshare_dev_mode', True, raising=False)
+
+
+@pytest.fixture
+def time_100(monkeypatch):
+    monkeypatch.setattr(time, 'time', lambda: 100)
+
+
+@pytest.fixture
+def time_strftime(monkeypatch):
+    monkeypatch.setattr(time, 'strftime', lambda _: 'Jun 06 2013 11:05:00')
+
+
+# #################################################
+# TESTS
+# #################################################
+
+
+class TestBuildSlug(object):
+    @pytest.mark.parametrize('test_input,expected', [
+        # VALID, two lowercase words, separated by a hyphen
+        ('syrup-enzyme', True),
+        ('caution-friday', True),
+
+        # VALID, two lowercase words, with one hyphenated compound word
+        ('drop-down-thimble', True),
+        ('unmixed-yo-yo', True),
+
+        # VALID, two lowercase hyphenated compound words, separated by hyphen
+        ('yo-yo-drop-down', True),
+        ('felt-tip-t-shirt', True),
+        ('hello-world', True),
+
+        # INVALID
+        ('Upper-Case', False),
+        ('digits-123', False),
+        ('too-many-hyphens-', False),
+        ('symbols-!@#$%', False)
+    ])
+    def test_build_slug_regex(self, test_input, expected):
+        """ Test that `SLUG_REGEX` accounts for the following patterns
+
+        There are a few hyphenated words in `wordlist.txt`:
+            * drop-down
+            * felt-tip
+            * t-shirt
+            * yo-yo
+
+        These words cause a few extra potential slug patterns:
+            * word-word
+            * hyphenated-word-word
+            * word-hyphenated-word
+            * hyphenated-word-hyphenated-word
+        """
+
+        assert bool(SLUG_REGEX.match(test_input)) == expected
+
+    def test_build_slug_unique(self):
+        assert common.build_slug() != common.build_slug()
+
+
+@pytest.mark.parametrize('directory_size', (5, 500, 5000))
+def test_dir_size(directory_size):
+    """ dir_size() should return the total size (in bytes) of all files
+    in a particular directory.
+
+    This test creates a temporary directory with a single file of a
+    particular size. After the test is complete, it deletes the
+    temporary directory.
+    """
+
+    # TODO: use helper function to create temporary file?
+    tmp_dir = tempfile.mkdtemp()
+    with tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False) as tmp_file:
+        tmp_file.write(b'*' * directory_size)
+
+    # tempfile.TemporaryDirectory raised error when given to `dir_size`
+    assert common.dir_size(tmp_dir) == directory_size
+    shutil.rmtree(tmp_dir)
+
+
+class TestEstimatedTimeRemaining(object):
+    @pytest.mark.parametrize('test_input,expected', (
+        ((2, 676, 12), '8h14m16s'),
+        ((14, 1049, 30), '1h26m15s'),
+        ((21, 450, 1), '33m42s'),
+        ((31, 1115, 80), '11m39s'),
+        ((336, 989, 32), '2m12s'),
+        ((603, 949, 38), '36s'),
+        ((971, 1009, 83), '1s')
+    ))
+    def test_estimated_time_remaining(self, test_input, expected, time_100):
+        assert common.estimated_time_remaining(*test_input) == expected
+
+    def test_estimated_time_remaining_time_elapsed_zero(self, time_100):
+        """ estimated_time_remaining() raises a ZeroDivisionError if
+        `time_elapsed` == 0
+        """
+
+        with pytest.raises(ZeroDivisionError):
+            common.estimated_time_remaining(10, 20, 100)
+
+    def test_estimated_time_remaining_download_rate_zero(self, time_100):
+        """ estimated_time_remaining() raises a ZeroDivision error if
+        `download_rate` == 0
+        """
+
+        with pytest.raises(ZeroDivisionError):
+            common.estimated_time_remaining(0, 37, 99)
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    (0, '0s'),
+    (26, '26s'),
+    (60, '1m'),
+    (947.35, '15m47s'),
+    (1847, '30m47s'),
+    (2193.94, '36m34s'),
+    (3600, '1h'),
+    (13426.83, '3h43m47s'),
+    (16293, '4h31m33s'),
+    (18392.14, '5h6m32s'),
+    (86400, '1d'),
+    (129674, '1d12h1m14s'),
+    (56404.12, '15h40m4s'),
+])
+def test_format_seconds(test_input, expected):
+    assert common.format_seconds(test_input) == expected
+
+
+@pytest.mark.parametrize('port_min,port_max', (
+    (random.randint(1024, 1500),
+     random.randint(1800, 2048)) for _ in range(100)
+))
+def test_get_available_port_returns_an_open_port(port_min, port_max):
+    """ get_available_port() should return an open port within the range """
+
+    port = common.get_available_port(port_min, port_max)
+    assert port_min <= port <= port_max
+    with socket.socket() as tmpsock:
+        tmpsock.bind(('127.0.0.1', port))
+
+
+# TODO: is there a way to parametrize (fixture, expected)?
+class TestGetPlatform(object):
+    def test_darwin(self, platform_darwin):
+        assert common.get_platform() == 'Darwin'
+
+    def test_linux(self, platform_linux):
+        assert common.get_platform() == 'Linux'
+
+    def test_windows(self, platform_windows):
+        assert common.get_platform() == 'Windows'
+
+
+# TODO: double-check these tests
+class TestGetResourcePath(object):
+    def test_onionshare_dev_mode(self, sys_onionshare_dev_mode):
+        prefix = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.abspath(
+                        inspect.getfile(
+                            inspect.currentframe())))), 'share')
+        assert (
+            common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
+            os.path.join(prefix, 'test_filename'))
+
+    def test_linux(self, platform_linux, sys_argv_sys_prefix):
+        prefix = os.path.join(sys.prefix, 'share/onionshare')
+        assert (
+            common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
+            os.path.join(prefix, 'test_filename'))
+
+    def test_frozen_darwin(self, platform_darwin, sys_frozen, sys_meipass):
+        prefix = os.path.join(sys._MEIPASS, 'share')
+        assert (
+            common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
+            os.path.join(prefix, 'test_filename'))
+
+    def test_frozen_windows(self, platform_windows, sys_frozen):
+        prefix = os.path.join(os.path.dirname(sys.executable), 'share')
+        assert (
+            common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
+            os.path.join(prefix, 'test_filename'))
+
+
+class TestGetTorPaths(object):
+    # @pytest.mark.skipif(sys.platform != 'Darwin', reason='requires MacOS') ?
+    def test_get_tor_paths_darwin(self, platform_darwin):
+        base_path = os.path.dirname(os.path.dirname(
+            os.path.dirname(common.get_resource_path(''))))
+        tor_path = os.path.join(base_path, 'Resources', 'Tor', 'tor')
+        tor_geo_ip_file_path = os.path.join(
+            base_path, 'Resources', 'Tor', 'geoip')
+        tor_geo_ipv6_file_path = os.path.join(
+            base_path, 'Resources', 'Tor', 'geoip6')
+        assert (common.get_tor_paths() ==
+                (tor_path, tor_geo_ip_file_path, tor_geo_ipv6_file_path))
+
+    # @pytest.mark.skipif(sys.platform != 'Linux', reason='requires Linux') ?
+    def test_get_tor_paths_linux(self, platform_linux):
+        assert (common.get_tor_paths() ==
+                ('/usr/bin/tor', '/usr/share/tor/geoip', '/usr/share/tor/geoip6'))
+
+    # @pytest.mark.skipif(sys.platform != 'Windows', reason='requires Windows') ?
+    def test_get_tor_paths_windows(self, platform_windows):
+        base_path = os.path.join(
+            os.path.dirname(os.path.dirname(common.get_resource_path(''))), 'tor')
+        tor_path = os.path.join(os.path.join(base_path, 'Tor'), "tor.exe")
+        tor_geo_ip_file_path = os.path.join(
+            os.path.join(os.path.join(base_path, 'Data'), 'Tor'), 'geoip')
+        tor_geo_ipv6_file_path = os.path.join(
+            os.path.join(os.path.join(base_path, 'Data'), 'Tor'), 'geoip6')
+        assert (common.get_tor_paths() ==
+                (tor_path, tor_geo_ip_file_path, tor_geo_ipv6_file_path))
+
+
+def test_get_version():
+    with open(common.get_resource_path('version.txt')) as f:
+        version = f.read().strip()
+
+    assert version == common.get_version()
+
+
+@pytest.mark.parametrize('test_input,expected', (
+    (1024 ** 0, '1.0 B'),
+    (1024 ** 1, '1.0 KiB'),
+    (1024 ** 2, '1.0 MiB'),
+    (1024 ** 3, '1.0 GiB'),
+    (1024 ** 4, '1.0 TiB'),
+    (1024 ** 5, '1.0 PiB'),
+    (1024 ** 6, '1.0 EiB'),
+    (1024 ** 7, '1.0 ZiB'),
+    (1024 ** 8, '1.0 YiB')
+))
+def test_human_readable_filesize(test_input, expected):
+    assert common.human_readable_filesize(test_input) == expected
+
+
+def test_log(time_strftime):
+    def test_func():
+        pass
+
+    # TODO: create and use `set_debug` fixture instead?
+    common.set_debug(True)
+
+    # From: https://stackoverflow.com/questions/1218933
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        common.log('TestModule', test_func)
+        common.log('TestModule', test_func, 'TEST_MSG')
+        output = buf.getvalue()
+
+    common.set_debug(False)
+
+    line_one, line_two, _ = output.split('\n')
+    assert LOG_MSG_REGEX.match(line_one)
+    assert LOG_MSG_REGEX.match(line_two)
+
+
+@pytest.mark.parametrize('test_input,expected', (
+    (common.random_string(
+        random.randint(2, 50),
+        random.choice((None, random.randint(2, 50)))),
+     True) for _ in range(50)
+))
+def test_random_string_regex(test_input, expected):
+    assert bool(RANDOM_STR_REGEX.match(test_input)) == expected
+
+
+# TODO: create and use `set_debug` fixture instead?
+class TestSetDebug(object):
+    def test_set_debug_true(self):
+        common.set_debug(True)
+        assert common.debug is True
+
+    def test_set_debug_false(self):
+        common.set_debug(False)
+        assert common.debug is False
+
+
+# TODO: ZipWriter doesn't enforce the `.zip` extension with custom filename
+class TestDefaultZipWriter(object):
+    def test_zw_filename(self, default_zw):
+        zw_filename = os.path.basename(default_zw.zip_filename)
+        assert bool(DEFAULT_ZW_FILENAME_REGEX.match(zw_filename))
+
+    def test_zipfile_filename_matches_zipwriter_filename(self, default_zw):
+        assert default_zw.z.filename == default_zw.zip_filename
+
+    def test_zipfile_allow_zip64(self, default_zw):
+        assert default_zw.z._allowZip64 is True
+
+    def test_zipfile_mode(self, default_zw):
+        assert default_zw.z.mode == 'w'
+
+    def test_callback(self, default_zw):
+        assert default_zw.processed_size_callback(None) is None
+
+    def test_add_file(self, default_zw):
+        tmp_file_size = 1000
+        # TODO: use helper function to create temporary file?
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            tmp_file.write(b'*' * tmp_file_size)
+
+        tmp_file_path = tmp_file.name
+        default_zw.add_file(tmp_file_path)
+
+        zipfile_info = default_zw.z.getinfo(os.path.basename(tmp_file_path))
+        assert zipfile_info.compress_type == zipfile.ZIP_DEFLATED
+        assert zipfile_info.file_size == tmp_file_size
+        assert zipfile_info.is_dir() is False
+
+        os.remove(tmp_file_path)
+        assert os.path.exists(tmp_file_path) is False
+
+    def test_add_directory(self, default_zw):
+        directory_size = 1000
+        tmp_dir = create_temporary_directory(directory_size)
+        current_size = default_zw._size
+        default_zw.add_dir(tmp_dir)
+
+        assert default_zw._size == current_size + directory_size
+        shutil.rmtree(tmp_dir)
+        assert os.path.exists(tmp_dir) is False
+
+
+def test_zip_writer_custom_filename(custom_zw):
+    assert bool(RANDOM_STR_REGEX.match(custom_zw.zip_filename))
+
+
+def create_temporary_directory(directory_size):
+    """ Create a temporary directory with a single file of a
+    particular size. Return directory path as a string
+    """
+
+    tmp_dir = tempfile.mkdtemp()
+    # create_temporary_file(directory=tmp_dir)
+
+    with tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False) as tmp_file:
+        tmp_file.write(b'*' * directory_size)
+
+    return tmp_dir
+
+
+# TODO: rewrite this helper function to DRY up tests that use temporary files
+# def create_temporary_file(directory=None, delete=False, file_size=100):
+#     if file_size <= 0:
+#         file_size = 100
+#     with tempfile.NamedTemporaryFile(dir=directory, delete=delete) as tmp_file:
+#         tmp_file.write(b'*' * file_size)
+#     return tmp_file.name

--- a/test/onionshare_common_test.py
+++ b/test/onionshare_common_test.py
@@ -412,7 +412,6 @@ class TestDefaultZipWriter(object):
         zipfile_info = default_zw.z.getinfo(os.path.basename(tmp_file_path))
         assert zipfile_info.compress_type == zipfile.ZIP_DEFLATED
         assert zipfile_info.file_size == tmp_file_size
-        assert zipfile_info.is_dir() is False
 
         os.remove(tmp_file_path)
         assert os.path.exists(tmp_file_path) is False

--- a/test/onionshare_settings_test.py
+++ b/test/onionshare_settings_test.py
@@ -1,0 +1,163 @@
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2017 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from onionshare import common, settings, strings
+
+
+@pytest.fixture
+def custom_version(monkeypatch):
+    monkeypatch.setattr(common, 'get_version', lambda: 'DUMMY_VERSION_1.2.3')
+
+
+@pytest.fixture
+def os_path_expanduser(monkeypatch):
+    monkeypatch.setattr('os.path.expanduser', lambda path: path)
+
+
+@pytest.fixture
+def settings_obj(custom_version, sys_onionshare_dev_mode, platform_linux):
+    return settings.Settings()
+
+
+class TestSettings:
+    def test_init(self, settings_obj):
+        assert settings_obj._settings == settings_obj.default_settings == {
+            'version': 'DUMMY_VERSION_1.2.3',
+            'connection_type': 'bundled',
+            'control_port_address': '127.0.0.1',
+            'control_port_port': 9051,
+            'socks_address': '127.0.0.1',
+            'socks_port': 9050,
+            'socket_file_path': '/var/run/tor/control',
+            'auth_type': 'no_auth',
+            'auth_password': '',
+            'close_after_first_download': True,
+            'systray_notifications': True,
+            'use_stealth': False,
+            'use_autoupdate': True,
+            'autoupdate_timestamp': None
+        }
+
+    def test_fill_in_defaults(self, settings_obj):
+        del settings_obj._settings['version']
+        settings_obj.fill_in_defaults()
+        assert settings_obj._settings['version'] == 'DUMMY_VERSION_1.2.3'
+
+    def test_load(self, settings_obj):
+        custom_settings = {
+            'version': 'CUSTOM_VERSION',
+            'socks_port': 9999,
+            'use_stealth': True
+        }
+        tmp_file, tmp_file_path = tempfile.mkstemp()
+        with open(tmp_file, 'w') as f:
+            json.dump(custom_settings, f)
+        settings_obj.filename = tmp_file_path
+        settings_obj.load()
+
+        assert settings_obj._settings['version'] == 'CUSTOM_VERSION'
+        assert settings_obj._settings['socks_port'] == 9999
+        assert settings_obj._settings['use_stealth'] is True
+
+        os.remove(tmp_file_path)
+        assert os.path.exists(tmp_file_path) is False
+
+    def test_save(self, monkeypatch, settings_obj):
+        monkeypatch.setattr(strings, '_', lambda _: '')
+
+        settings_filename = 'default_settings.json'
+        tmp_dir = tempfile.gettempdir()
+        settings_path = os.path.join(tmp_dir, settings_filename)
+        settings_obj.filename = settings_path
+        settings_obj.save()
+        with open(settings_path, 'r') as f:
+            settings = json.load(f)
+
+        assert settings_obj._settings == settings
+
+        os.remove(settings_path)
+        assert os.path.exists(settings_path) is False
+
+    def test_get(self, settings_obj):
+        assert settings_obj.get('version') == 'DUMMY_VERSION_1.2.3'
+        assert settings_obj.get('connection_type') == 'bundled'
+        assert settings_obj.get('control_port_address') == '127.0.0.1'
+        assert settings_obj.get('control_port_port') == 9051
+        assert settings_obj.get('socks_address') == '127.0.0.1'
+        assert settings_obj.get('socks_port') == 9050
+        assert settings_obj.get('socket_file_path') == '/var/run/tor/control'
+        assert settings_obj.get('auth_type') == 'no_auth'
+        assert settings_obj.get('auth_password') == ''
+        assert settings_obj.get('close_after_first_download') is True
+        assert settings_obj.get('systray_notifications') is True
+        assert settings_obj.get('use_stealth') is False
+        assert settings_obj.get('use_autoupdate') is True
+        assert settings_obj.get('autoupdate_timestamp') is None
+
+    def test_set_version(self, settings_obj):
+        settings_obj.set('version', 'CUSTOM_VERSION')
+        assert settings_obj._settings['version'] == 'CUSTOM_VERSION'
+
+    def test_set_control_port_port(self, settings_obj):
+        settings_obj.set('control_port_port', 999)
+        assert settings_obj._settings['control_port_port'] == 999
+
+        settings_obj.set('control_port_port', 'NON_INTEGER')
+        assert settings_obj._settings['control_port_port'] == 9051
+
+    def test_set_socks_port(self, settings_obj):
+        settings_obj.set('socks_port', 888)
+        assert settings_obj._settings['socks_port'] == 888
+
+        settings_obj.set('socks_port', 'NON_INTEGER')
+        assert settings_obj._settings['socks_port'] == 9050
+
+    def test_filename_darwin(
+            self,
+            custom_version,
+            monkeypatch,
+            os_path_expanduser,
+            platform_darwin):
+        obj = settings.Settings()
+        assert (obj.filename ==
+                '~/Library/Application Support/OnionShare/onionshare.json')
+
+    def test_filename_linux(
+            self,
+            custom_version,
+            monkeypatch,
+            os_path_expanduser,
+            platform_linux):
+        obj = settings.Settings()
+        assert obj.filename == '~/.config/onionshare/onionshare.json'
+
+    def test_filename_windows(
+            self,
+            custom_version,
+            monkeypatch,
+            platform_windows):
+        monkeypatch.setenv('APPDATA', 'C:')
+        obj = settings.Settings()
+        assert obj.filename == 'C:\\OnionShare\\onionshare.json'

--- a/test/onionshare_strings_test.py
+++ b/test/onionshare_strings_test.py
@@ -17,30 +17,55 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import locale, os
+
+import types
+
+import pytest
+
 from onionshare import common, strings
 
-# Stub get_resource_path so it finds the correct path while running tests
-def get_resource_path(filename):
-    resources_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'share')
-    path = os.path.join(resources_dir, filename)
-    return path
-common.get_resource_path = get_resource_path
+
+# # Stub get_resource_path so it finds the correct path while running tests
+# def get_resource_path(filename):
+#     resources_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'share')
+#     path = os.path.join(resources_dir, filename)
+#     return path
+# common.get_resource_path = get_resource_path
+
 
 def test_starts_with_empty_strings():
-    """creates an empty strings dict by default"""
+    """ Creates an empty strings dict by default """
     assert strings.strings == {}
 
 
-def test_load_strings_defaults_to_english():
-    """load_strings() loads English by default"""
-    locale.getdefaultlocale = lambda: ('en_US', 'UTF-8')
-    strings.load_strings(common)
-    assert strings._('wait_for_hs') == "Waiting for HS to be ready:"
+def test_underscore_is_function():
+    assert callable(strings._) and isinstance(strings._, types.FunctionType)
 
 
-def test_load_strings_loads_other_languages():
-    """load_strings() loads other languages in different locales"""
-    locale.getdefaultlocale = lambda: ('fr_FR', 'UTF-8')
-    strings.load_strings(common, "fr")
-    assert strings._('wait_for_hs') == "En attente du HS:"
+class TestLoadStrings:
+    def test_load_strings_defaults_to_english(
+            self, locale_en, sys_onionshare_dev_mode):
+        """ load_strings() loads English by default """
+        strings.load_strings(common)
+        assert strings._('wait_for_hs') == "Waiting for HS to be ready:"
+
+
+    def test_load_strings_loads_other_languages(
+            self, locale_fr, sys_onionshare_dev_mode):
+        """ load_strings() loads other languages in different locales """
+        strings.load_strings(common, "fr")
+        assert strings._('wait_for_hs') == "En attente du HS:"
+
+    def test_load_partial_strings(
+            self, locale_ru, sys_onionshare_dev_mode):
+        strings.load_strings(common)
+        assert strings._("give_this_url") == (
+            "Отправьте эту ссылку тому человеку, "
+            "которому вы хотите передать файл:")
+        assert strings._('wait_for_hs') == "Waiting for HS to be ready:"
+
+    def test_load_invalid_locale(
+            self, locale_invalid, sys_onionshare_dev_mode):
+        """ load_strings() raises a KeyError for an invalid locale """
+        with pytest.raises(KeyError):
+            strings.load_strings(common, 'XX')

--- a/test/onionshare_test.py
+++ b/test/onionshare_test.py
@@ -16,11 +16,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+
 import os
 
 import pytest
 
-from onionshare import onionshare
+from onionshare import OnionShare
 
 
 class MyOnion:
@@ -33,9 +34,9 @@ class MyOnion:
         return 'test_service_id.onion'
 
 
-@pytest.fixture()
+@pytest.fixture
 def onionshare_obj():
-    return onionshare.OnionShare(MyOnion())
+    return OnionShare(MyOnion())
 
 
 class TestOnionShare:

--- a/test/onionshare_test.py
+++ b/test/onionshare_test.py
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import os
 
 import pytest
 
@@ -32,7 +33,6 @@ class MyOnion:
         return 'test_service_id.onion'
 
 
-# pytest > 2.9 only needs pytest.fixture
 @pytest.fixture()
 def onionshare_obj():
     return onionshare.OnionShare(MyOnion())
@@ -40,7 +40,6 @@ def onionshare_obj():
 
 class TestOnionShare:
     def test_init(self, onionshare_obj):
-        # test onion? own fixture?
         assert onionshare_obj.hidserv_dir is None
         assert onionshare_obj.onion_host is None
         assert onionshare_obj.stealth is None
@@ -75,9 +74,10 @@ class TestOnionShare:
         assert onionshare_obj.onion_host == '127.0.0.1:{}'.format(
             onionshare_obj.port)
 
-    def test_cleanup(self, onionshare_obj):
-        # create temporary files/directories and then remove them
-        # use helper function from other file (use conftest.py???)
-        onionshare_obj.cleanup_filenames = []  # add temporary filenames & dirs
-        # remove the files & dirs
+    def test_cleanup(self, onionshare_obj, temp_dir_1024, temp_file_1024):
+        onionshare_obj.cleanup_filenames = [temp_dir_1024, temp_file_1024]
+        onionshare_obj.cleanup()
+
+        assert os.path.exists(temp_dir_1024) is False
+        assert os.path.exists(temp_dir_1024) is False
         assert onionshare_obj.cleanup_filenames == []


### PR DESCRIPTION
@micahflee ,

I apologize for the delay with this pull request (to help with #404 ). When I saw that message (a few weeks ago) that the Tails guys were writing tests, I just kind of assumed they would do a better job than me so I stopped working on it. When I saw your message a few days ago clarifying what they were actually testing, I thought I would start back up on these tests.

Here is a summary of the coverage so far (inside of PyCharm):

![onionshare_coverage](https://user-images.githubusercontent.com/24502053/27987880-9ea6c4b8-63d2-11e7-805c-d8a821dd02e8.png)

The highlighted files are the ones I've been writing/modifying the tests for. I figured out why that issue was happening to you before. For `pytest <= 2.9`, you have to use `@pytest.yield_fixture` instead of `@pytest.fixture` (for fixtures that use `yield` statements). I also downgraded my Python version and `pytest` version to try and match yours to ensure the tests will pass for you.

```
============================= test session starts ==============================
platform linux -- Python 3.5.3, pytest-2.9.2, py-1.4.34, pluggy-0.3.1
```

Here is a link to the latest Travis build showing the tests passing (and coverage of `onionshare` using the `pytest-cov` plugin) on all desired Python versions, `3.4+`.
* https://travis-ci.org/delirious-lettuce/onionshare

![python_34_travis](https://user-images.githubusercontent.com/24502053/27988140-193f05e6-63d8-11e7-973e-cebdfaaa4080.png)

This is still a work-in-progress and I haven't updated the setup info quite yet but I will do that later today. As you can see, I haven't covered all of the files yet but there are some good reasons.

* `web.py` I'm not exactly sure how to properly test a Flask app and will have to do more research on that.
* `onion.py` I'm also not exactly sure how to properly test the Tor parts (since I'm not very experienced with Tor overall). 
* `socks.py` Again, I'm not exactly sure how to properly test networking and sockets

Overall, it might be easier for me just to finish the setup commands for this pull request. I've been playing with the travis settings using `pip install` instead of system packages because of error relating to this:

* https://docs.travis-ci.com/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs

    > CI Environment uses separate virtualenv instances for each Python version. System Python is not used and should not be relied on. If you need to install Python packages, do it via pip and not apt.
    >
    > If you decide to use apt anyway, note that Python system packages only include Python 2.7 libraries on Ubuntu 12.04 LTS. This means that the packages installed from the repositories are not available in other virtualenvs even if you use the –system-site-packages option.

Coveralls is not needed (I was only using it for my own reference) and I can easily take it out of `.travis.yml`.

---
I am open to any input/suggestions on how to improve these tests since I am not an expert with `pytest`. I have learned a lot of things while writing them but if you have any questions about why I did something in a particular way, feel free to ask (and/or correct me!).
