### PR TITLE
Cleanup and minor fixes

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import base64
 import hashlib
 import inspect
-import math
 import os
 import platform
 import random
@@ -143,14 +142,14 @@ def human_readable_filesize(b):
     """
     thresh = 1024.0
     if b < thresh:
-        return '{0:.1f} B'.format(b)
-    units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+        return '{:.1f} B'.format(b)
+    units = ('KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB')
     u = 0
     b /= thresh
     while b >= thresh:
         b /= thresh
         u += 1
-    return '{0:.1f} {1:s}'.format(round(b, 1), units[u])
+    return '{:.1f} {}'.format(b, units[u])
 
 
 def format_seconds(seconds):

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -433,6 +433,13 @@ class Onion(object):
         self.stealth = False
         self.service_id = None
 
+        try:
+            # Delete the temporary tor data directory
+            self.tor_data_directory.cleanup()
+        except AttributeError:
+            # Skip if cleanup was somehow run before connect
+            pass
+
     def get_tor_socks_port(self):
         """
         Returns a (address, port) tuple for the Tor SOCKS port

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -18,9 +18,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import platform, os, json
+import json
+import os
+import platform
 
 from . import strings, common
+
 
 class Settings(object):
     """
@@ -95,7 +98,7 @@ class Settings(object):
             try:
                 common.log('Settings', 'load', 'Trying to load {}'.format(self.filename))
                 with open(self.filename, 'r') as f:
-                    self._settings = json.loads(f.read())
+                    self._settings = json.load(f)
                     self.fill_in_defaults()
             except:
                 pass

--- a/onionshare/strings.py
+++ b/onionshare/strings.py
@@ -17,9 +17,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import json, locale, os
+import json
+import locale
+import os
 
 strings = {}
+
 
 def load_strings(common, default="en"):
     """
@@ -27,7 +30,6 @@ def load_strings(common, default="en"):
     if the translation does not exist.
     """
     global strings
-    p = common.get_platform()
 
     # find locale dir
     locale_dir = common.get_resource_path('locale')
@@ -37,10 +39,9 @@ def load_strings(common, default="en"):
     for filename in os.listdir(locale_dir):
         abs_filename = os.path.join(locale_dir, filename)
         lang, ext = os.path.splitext(filename)
-        if abs_filename.endswith('.json'):
+        if ext == '.json':
             with open(abs_filename, encoding='utf-8') as f:
-                lang_json = f.read()
-                translations[lang] = json.loads(lang_json)
+                translations[lang] = json.load(f)
 
     strings = translations[default]
     lc, enc = locale.getdefaultlocale()


### PR DESCRIPTION
#### `common.py`

* Remove unused import `math`
* Remove unnecessary format indexes
* Use tuple instead of list (for `units`). Slight memory saving because of immutability
* Remove unnecessary use of `round` in `'{0:.1f} {1:s}'.format(round(b, 1), units[u])`

    ```python
    >>> for num in (1.23, 1.55, 2.55):
    ...     print('num: {}\n\tround:  {}\n\tformat: {:.1f}\n'.format(num, round(num, 1), num))
    ... 
    num: 1.23
        round:  1.2
        format: 1.2
    
    num: 1.55
        round:  1.6
        format: 1.6
    
    num: 2.55
        round:  2.5
        format: 2.5
    ```

#### `settings.py`

* [One import per line](https://pep8.org/#imports)
* Two blank lines above class definition
* Use `json.load(f)` instead of creating a string of the file contents before converting it to json, `json.loads(f.read())`. One step instead of two.

#### `strings.py`

* [One import per line](https://pep8.org/#imports)
* Two blank lines above function definitions
* Remove unused variable `p = common.get_platform()` from `load_strings`
* Use previously unused `ext` variable to check file extension
* Use `json.load(f)` instead of creating a string of the file contents before converting it to json, `json.loads(f.read())`. One step instead of two.

#### `web.py`

* [Reorder imports](https://pep8.org/#imports), one per line and group multiple imports from Flask
* Two blank lines above function definitions
* Use `tempfile.gettempdir` for more fallback options for different systems. Then, use `os.path.join` to use proper system-specific separators for creating paths.

    #### [tempfile.gettempdir()](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)

    > Return the name of the directory used for temporary files. This defines the default value for the dir argument to all functions in this module.
    > 
    > Python searches a standard list of directories to find one which the calling user can create files in. The list is:
    > 
    > 1. The directory named by the TMPDIR environment variable.
    > 2. The directory named by the TEMP environment variable.
    > 3. The directory named by the TMP environment variable.
    > 4. A platform-specific location:
    >     * On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order.
    >     * On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.
    > 5. As a last resort, the current working directory.
    > The result of this search is cached, see the description of tempdir below.
* Remove unneeded `global slug` since `slug` is not being reassigned inside of `check_slug_candidate`
* Add single space after commas

---
#### Edit

While writing tests for `onion.py` (#460), I noticed that the temporary tor data directory was not being deleted when the `Onion.cleanup` method was run. It's a very simple fix because it is a built-in feature of `tempfile.TemporaryDirectory`.

> #### [tempfile.TemporaryDirectory(suffix=None, prefix=None, dir=None)](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory)
> This function securely creates a temporary directory using the same rules as mkdtemp(). 
> ...
> ***The directory can be explicitly cleaned up by calling the cleanup() method.***

I also wrapped the call to `TemporaryDirectory.cleanup` inside a `try/except` just in case `Onion.cleanup` was somehow called before `Onion.connect` (since that is where `self.tor_data_directory` is first assigned).
