### PR TITLE
99% coverage of `onionshare.__init__.py`

### DIFF
--- a/test/onionshare_init_test.py
+++ b/test/onionshare_init_test.py
@@ -20,10 +20,10 @@ import argparse
 import os
 import sys
 import threading
+import time
 from unittest.mock import Mock, call
 
 import pytest
-import time
 
 import onionshare
 from onionshare import (

--- a/test/onionshare_init_test.py
+++ b/test/onionshare_init_test.py
@@ -27,7 +27,7 @@ import time
 
 import onionshare
 from onionshare import (
-    main, common, Onion, OnionShare, web, TorErrorInvalidSetting
+    Onion, OnionShare, TorErrorInvalidSetting, common, main, strings, web
 )
 
 
@@ -128,6 +128,11 @@ def mock_web_stop(monkeypatch):
 
 
 @pytest.fixture
+def strings_strings(monkeypatch):
+    monkeypatch.setattr(strings, 'strings', {})
+
+
+@pytest.fixture
 def sys_argv_filename_only(monkeypatch):
     monkeypatch.setattr('sys.argv', ['', '/TEST_FILENAME.txt'])
 
@@ -162,6 +167,7 @@ class TestMain:
             common_get_version,
             mock_os_chdir,
             platform_darwin,
+            strings_strings,
             sys_onionshare_dev_mode):
 
         test_path = '/path/to/config.json'
@@ -179,6 +185,7 @@ class TestMain:
             common_get_version,
             mock_argparse_argument_parser,
             platform_linux,
+            strings_strings,
             sys_onionshare_dev_mode):
 
         (mock_argparse_argument_parser.
@@ -213,6 +220,7 @@ class TestMain:
             mock_web_debug_mode,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_onionshare_dev_mode):
 
         monkeypatch.setattr('sys.argv', [
@@ -246,6 +254,7 @@ class TestMain:
             mock_os_path_exists,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode):
 
@@ -275,6 +284,7 @@ class TestMain:
             mock_sys_exit,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode):
 
@@ -310,6 +320,7 @@ class TestMain:
             mock_sys_exit,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode):
 
@@ -346,6 +357,7 @@ class TestMain:
             mock_sys_exit,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode):
 
@@ -396,6 +408,7 @@ class TestMain:
             mock_web_stop,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode,
             web_start,
@@ -482,6 +495,7 @@ class TestMain:
             mock_web_stop,
             monkeypatch,
             platform_linux,
+            strings_strings,
             sys_argv_filename_only,
             sys_onionshare_dev_mode,
             web_start,
@@ -490,6 +504,7 @@ class TestMain:
             web_zip_filesize):
         """
         Exact same test as above except for the `stealth` flag
+        TODO: figure out a way to get rid of the repetition
         """
 
         monkeypatch.setattr('sys.argv', ['', '--stealth', '/TEST_FILENAME.txt'])

--- a/test/onionshare_init_test.py
+++ b/test/onionshare_init_test.py
@@ -16,11 +16,545 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
+import argparse
+import os
+import sys
+import threading
 from unittest.mock import Mock, call
 
 import pytest
+import time
+
+import onionshare
+from onionshare import (
+    main, common, Onion, OnionShare, web, TorErrorInvalidSetting
+)
+
+
+@pytest.fixture
+def common_get_version(monkeypatch):
+    monkeypatch.setattr(common, 'get_version', lambda: 'DUMMY_VERSION_1.2.3')
+
+
+@pytest.fixture
+def mock_argparse_argument_parser(monkeypatch):
+    m = Mock(spec=argparse.ArgumentParser)
+    monkeypatch.setattr('argparse.ArgumentParser', m)
+    return m
+
+
+@pytest.fixture
+def mock_common_set_debug(monkeypatch):
+    m = Mock(spec=common.set_debug)
+    monkeypatch.setattr(common, 'set_debug', m)
+    return m
+
+
+@pytest.fixture
+def mock_onion(monkeypatch):
+    m = Mock(spec=Onion)
+    monkeypatch.setattr(onionshare, 'Onion', m)
+    return m
+
+
+@pytest.fixture
+def mock_onionshare(monkeypatch):
+    m = Mock(spec=OnionShare)
+    monkeypatch.setattr(onionshare, 'OnionShare', m)
+    return m
+
+
+@pytest.fixture
+def mock_os_access(monkeypatch):
+    m = Mock(spec=os.access)
+    monkeypatch.setattr('os.access', m)
+    return m
+
+
+@pytest.fixture
+def mock_os_chdir(monkeypatch):
+    m = Mock(spec=os.chdir)
+    monkeypatch.setattr('os.chdir', m)
+    return m
+
+
+@pytest.fixture
+def mock_os_path_exists(monkeypatch):
+    m = Mock(spec=os.path.exists)
+    monkeypatch.setattr('os.path.exists', m)
+    return m
+
+
+@pytest.fixture
+def mock_sys_exit(monkeypatch):
+    m = Mock(spec=sys.exit)
+    monkeypatch.setattr('sys.exit', m)
+    return m
+
+
+@pytest.fixture
+def mock_threading_thread(monkeypatch):
+    m = Mock(spec=threading.Thread)
+    monkeypatch.setattr('threading.Thread', m)
+    return m
+
+
+@pytest.fixture
+def mock_time_sleep(monkeypatch):
+    m = Mock(spec=time.sleep)
+    monkeypatch.setattr('time.sleep', m)
+    return m
+
+
+@pytest.fixture
+def mock_web_debug_mode(monkeypatch):
+    m = Mock(spec=web.debug_mode)
+    monkeypatch.setattr(web, 'debug_mode', m)
+    return m
+
+
+@pytest.fixture
+def mock_web_set_file_info(monkeypatch):
+    m = Mock(spec=web.set_file_info)
+    monkeypatch.setattr(web, 'set_file_info', m)
+    return m
+
+
+@pytest.fixture
+def mock_web_stop(monkeypatch):
+    m = Mock(spec=web.stop)
+    monkeypatch.setattr(web, 'stop', m)
+    return m
+
+
+@pytest.fixture
+def sys_argv_filename_only(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['', '/TEST_FILENAME.txt'])
+
+
+@pytest.fixture
+def web_slug(monkeypatch):
+    monkeypatch.setattr(web, 'slug', 'TEST_SLUG')
+
+
+@pytest.fixture
+def web_start(monkeypatch):
+    monkeypatch.setattr(web, 'start', 9999)
+
+
+@pytest.fixture
+def web_zip_filename(monkeypatch):
+    monkeypatch.setattr(web, 'zip_filename', '/TEST_FILENAME.txt')
+
+
+@pytest.fixture
+def web_zip_filesize(monkeypatch):
+    monkeypatch.setattr(web, 'zip_filesize', 157286400)
+
+
+class OnionshareTestPause(Exception):
+    pass
 
 
 class TestMain:
-    pass
+    def test_osx_chdir(
+            self,
+            common_get_version,
+            mock_os_chdir,
+            platform_darwin,
+            sys_onionshare_dev_mode):
+
+        test_path = '/path/to/config.json'
+        mock_os_chdir.side_effect = OnionshareTestPause
+
+        try:
+            main(test_path)
+        except OnionshareTestPause:
+            pass
+
+        mock_os_chdir.assert_called_once_with(test_path)
+
+    def test_argparse_arguments(
+            self,
+            common_get_version,
+            mock_argparse_argument_parser,
+            platform_linux,
+            sys_onionshare_dev_mode):
+
+        (mock_argparse_argument_parser.
+         return_value.
+         parse_args.
+         side_effect) = OnionshareTestPause
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        (mock_argparse_argument_parser.
+         return_value.
+         add_argument.
+         assert_has_calls((
+             call('--local-only', action='store_true', dest='local_only', help='Do not attempt to use tor: for development only'),
+             call('--stay-open', action='store_true', dest='stay_open', help='Keep onion service running after download has finished'),
+             call('--stealth', action='store_true', dest='stealth', help='Create stealth onion service (advanced)'),
+             call('--debug', action='store_true', dest='debug', help='Log application errors to stdout, and log web errors to disk'),
+             call('--config', default=False, help='Path to a custom JSON config file (optional)', metavar='config'),
+             call('filename', help='List of files or folders to share', metavar='filename', nargs='+')
+         )))
+
+    def test_parse_args(
+            self,
+            common_get_version,
+            mock_common_set_debug,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            mock_web_debug_mode,
+            monkeypatch,
+            platform_linux,
+            sys_onionshare_dev_mode):
+
+        monkeypatch.setattr('sys.argv', [
+            'python',
+            '--local-only',
+            '--stay-open',
+            '--stealth',
+            '--debug',
+            '--config',
+            'TEST_CONFIG.json',
+            '/TEST_FILENAME.txt'])
+
+        mock_os_access.return_value = False
+        mock_os_path_exists.return_value = False
+        mock_sys_exit.side_effect = OnionshareTestPause
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        mock_common_set_debug.assert_called_once_with(True)
+        mock_web_debug_mode.assert_called_once_with()
+        mock_sys_exit.assert_called_once_with()
+
+    def test_onion(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_os_access,
+            mock_os_path_exists,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode):
+
+        mock_onion.return_value.connect.side_effect = OnionshareTestPause
+        mock_os_access.return_value = True
+        mock_os_path_exists.return_value = True
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        (mock_onion.
+         return_value.
+         connect.
+         assert_called_once_with(
+             config=False,
+             settings=False
+         ))
+
+    def test_onion_tor_exception(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode):
+
+        tor_test_error_msg = 'Tor test error message'
+        (mock_onion.
+         return_value.
+         connect.
+         side_effect) = TorErrorInvalidSetting(tor_test_error_msg)
+        mock_os_access.return_value = True
+        mock_os_path_exists.return_value = True
+        mock_sys_exit.side_effect = OnionshareTestPause
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        (mock_onion.
+         return_value.
+         connect.
+         assert_called_once_with(
+             config=False,
+             settings=False
+         ))
+        mock_sys_exit.assert_called_once_with(tor_test_error_msg)
+
+    def test_onion_keyboard_interrupt(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode):
+
+        (mock_onion.
+         return_value.
+         connect.
+         side_effect) = KeyboardInterrupt
+        mock_os_access.return_value = True
+        mock_os_path_exists.return_value = True
+        mock_sys_exit.side_effect = OnionshareTestPause
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        (mock_onion.
+         return_value.
+         connect.
+         assert_called_once_with(
+             config=False,
+             settings=False
+         ))
+
+        mock_sys_exit.assert_called_once_with()
+
+    def test_onionshare_keyboard_interrupt(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_onionshare,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode):
+
+        (mock_onionshare.
+         return_value.
+         start_onion_service.
+         side_effect) = KeyboardInterrupt
+        mock_os_access.return_value = True
+        mock_os_path_exists.return_value = True
+        mock_sys_exit.side_effect = OnionshareTestPause
+
+        try:
+            main()
+        except OnionshareTestPause:
+            pass
+
+        (mock_onion.
+         return_value.
+         connect.
+         assert_called_once_with(
+             config=False,
+             settings=False
+         ))
+
+        (mock_onionshare.
+         return_value.
+         set_stealth.
+         assert_called_once_with(False))
+
+        (mock_onionshare.
+         return_value.
+         start_onion_service.
+         assert_called_once_with())
+
+        mock_sys_exit.assert_called_once_with()
+
+    def test_service(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_onionshare,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            mock_threading_thread,
+            mock_time_sleep,
+            mock_web_set_file_info,
+            mock_web_stop,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode,
+            web_start,
+            web_slug,
+            web_zip_filename,
+            web_zip_filesize):
+
+        (mock_onionshare.
+         return_value.
+         onion_host) = 'TEST_HOST'
+
+        (mock_onionshare.
+         return_value.
+         port) = 8888
+
+        (mock_onionshare.
+         return_value.
+         stay_open) = True
+
+        mock_os_access.return_value = True
+
+        mock_os_path_exists.return_value = True
+
+        (mock_threading_thread.
+         return_value.
+         is_alive.side_effect) = (True, KeyboardInterrupt)
+
+        main()
+
+        # tests
+        mock_web_set_file_info.assert_called_once_with(['/TEST_FILENAME.txt'])
+
+        (mock_onionshare.
+         return_value.
+         cleanup_filenames.
+         append.
+         assert_called_once_with(web.zip_filename))
+
+        (mock_threading_thread.
+         assert_called_once_with(
+             target=web.start,
+             args=(mock_onionshare.return_value.port,
+                   mock_onionshare.return_value.stay_open)
+         ))
+
+        assert mock_threading_thread.return_value.daemon is True
+
+        (mock_threading_thread.
+         return_value.
+         start.
+         assert_called_once_with())
+
+        assert (mock_threading_thread.
+                return_value.
+                is_alive.
+                call_count == 2)
+
+        mock_time_sleep.assert_has_calls((call(0.2), call(100)))
+
+        mock_web_stop.assert_called_once_with(
+            mock_onionshare.return_value.port)
+
+        (mock_onionshare.
+         return_value.
+         cleanup.
+         assert_called_once_with())
+
+        (mock_onion.
+         return_value.
+         cleanup.
+         assert_called_once_with())
+
+    def test_stealth_service(
+            self,
+            common_get_version,
+            mock_onion,
+            mock_onionshare,
+            mock_os_access,
+            mock_os_path_exists,
+            mock_sys_exit,
+            mock_threading_thread,
+            mock_time_sleep,
+            mock_web_set_file_info,
+            mock_web_stop,
+            monkeypatch,
+            platform_linux,
+            sys_argv_filename_only,
+            sys_onionshare_dev_mode,
+            web_start,
+            web_slug,
+            web_zip_filename,
+            web_zip_filesize):
+        """
+        Exact same test as above except for the `stealth` flag
+        """
+
+        monkeypatch.setattr('sys.argv', ['', '--stealth', '/TEST_FILENAME.txt'])
+
+        (mock_onionshare.
+         return_value.
+         onion_host) = 'TEST_HOST'
+
+        (mock_onionshare.
+         return_value.
+         port) = 8888
+
+        (mock_onionshare.
+         return_value.
+         stay_open) = True
+
+        mock_os_access.return_value = True
+
+        mock_os_path_exists.return_value = True
+
+        (mock_threading_thread.
+         return_value.
+         is_alive.side_effect) = (True, KeyboardInterrupt)
+
+        main()
+
+        # tests
+        mock_web_set_file_info.assert_called_once_with(['/TEST_FILENAME.txt'])
+
+        (mock_onionshare.
+         return_value.
+         cleanup_filenames.
+         append.
+         assert_called_once_with(web.zip_filename))
+
+        (mock_threading_thread.
+         assert_called_once_with(
+             target=web.start,
+             args=(mock_onionshare.return_value.port,
+                   mock_onionshare.return_value.stay_open)
+         ))
+
+        assert mock_threading_thread.return_value.daemon is True
+
+        (mock_threading_thread.
+         return_value.
+         start.
+         assert_called_once_with())
+
+        assert (mock_threading_thread.
+                return_value.
+                is_alive.
+                call_count == 2)
+
+        mock_time_sleep.assert_has_calls((call(0.2), call(100)))
+
+        mock_web_stop.assert_called_once_with(
+            mock_onionshare.return_value.port)
+
+        (mock_onionshare.
+         return_value.
+         cleanup.
+         assert_called_once_with())
+
+        (mock_onion.
+         return_value.
+         cleanup.
+         assert_called_once_with())

--- a/test/onionshare_init_test.py
+++ b/test/onionshare_init_test.py
@@ -1,0 +1,26 @@
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2017 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from unittest.mock import Mock, call
+
+import pytest
+
+
+class TestMain:
+    pass


### PR DESCRIPTION
@micahflee ,

This one was interesting to write tests for because it is one long function. It would have been much easier to test if it was broken up into smaller functions.

To make the tests themselves a bit smaller, I used [`Mock.side_effect`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.side_effect) to raise a custom exception in a few places to stop the tests early. The last tests get more complicated as they have more setup involved and must run through the whole `main` function.

Right now, the coverage of `onionshare.__init__` is at 99%. I think I can get rid of the last `1%` by adding `# pragma: no cover` either beside `if __name__ == '__main__':` or beside `main()` (underneath it). The reason I didn't (yet) is that there is another way by adding a `.coveragerc` file ([link to the coverage docs](https://coverage.readthedocs.io/en/coverage-4.2/excluding.html)). Anyways, it's just another file that seems kind of unnecessary for the project.

```
[report]
exclude_lines =
    pragma: no cover
    def __repr__
    if self.debug:
    if settings.DEBUG
    raise AssertionError
    raise NotImplementedError
    if 0:
    if __name__ == .__main__.:

```

![onionshare_init_coverage](https://user-images.githubusercontent.com/24502053/28099888-44f4e588-667c-11e7-8ab2-cf2348cedfd7.png)

Anyways, let me know what you think!
