### PR TITLE
Fix flask version parsing

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -36,7 +36,7 @@ def _safe_select_jinja_autoescape(self, filename):
 # by default. To prevent content injection through template variables in
 # earlier versions of Flask, we force autoescaping in the Jinja2 template
 # engine if we detect a Flask version with insecure default behavior.
-if Version(flask_version) < Version('0.11'):
+if Version(flask_version.replace('-dev','')) < Version('0.11'):
     # Monkey-patch in the fix from https://github.com/pallets/flask/commit/99c99c4c16b1327288fd76c44bc8635a1de452bc
     Flask.select_jinja_autoescape = _safe_select_jinja_autoescape
 


### PR DESCRIPTION
PR chops the '-dev' suffix from the flask version string dynamically. Probably not safe if Flask start changing their usual version formula but should generally be fine for now.

Made a prospective v1.2.dev1 version tag on my side but you can tag it how you like. Would be great if you can get a release out ASAP so we/someone can fixup the Arch Linux PKGBUILD.
Fixes: #442