### PR TITLE
Update Tor bundles for OS X and Windows

### DIFF
--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, zipfile, io, shutil, subprocess
 import urllib.request
 
 def main():
-    dmg_url = 'https://www.torproject.org/dist/torbrowser/6.5.2/TorBrowser-6.5.2-osx64_en-US.dmg'
-    dmg_filename = 'TorBrowser-6.5.2-osx64_en-US.dmg'
-    expected_dmg_sha256 = '0b11d12f9ff0d82ceb2a9a4dba9c4ba234da47640c8e25e76e4092a7d3a90ef6'
+    dmg_url = 'https://dist.torproject.org/torbrowser/7.0.8/TorBrowser-7.0.8-osx64_en-US.dmg'
+    dmg_filename = 'TorBrowser-7.0.8-osx64_en-US.dmg'
+    expected_dmg_sha256 = '11ad9163a5bfb82c5c3985b6c7c5f258b9677b4ae1ccfa3a5aee6dfc12e09d80'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))

--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -28,7 +28,7 @@ import inspect, os, sys, hashlib, zipfile, io, shutil, subprocess
 import urllib.request
 
 def main():
-    dmg_url = 'https://dist.torproject.org/torbrowser/7.0.8/TorBrowser-7.0.8-osx64_en-US.dmg'
+    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.8/TorBrowser-7.0.8-osx64_en-US.dmg'
     dmg_filename = 'TorBrowser-7.0.8-osx64_en-US.dmg'
     expected_dmg_sha256 = '11ad9163a5bfb82c5c3985b6c7c5f258b9677b4ae1ccfa3a5aee6dfc12e09d80'
 

--- a/install/get-tor-windows.py
+++ b/install/get-tor-windows.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, zipfile, io, shutil
 import urllib.request
 
 def main():
-    zip_url = 'https://www.torproject.org/dist/torbrowser/6.5.1/tor-win32-0.2.9.10.zip'
-    zip_filename = 'tor-win32-0.2.9.10.zip'
-    expected_zip_sha256 = '56e639cd73c48f383fd638568e01ca07750211fca79c87e668cf8baccbf9d38a'
+    zip_url = 'https://dist.torproject.org/torbrowser/7.0.8/tor-win32-0.3.1.7.zip'
+    zip_filename = 'tor-win32-0.3.1.7.zip'
+    expected_zip_sha256 = 'fb4c330361d8a7449ed4b9a30848bdad47616166af64f7ace4c71ead83464780'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))

--- a/install/get-tor-windows.py
+++ b/install/get-tor-windows.py
@@ -28,7 +28,7 @@ import inspect, os, sys, hashlib, zipfile, io, shutil
 import urllib.request
 
 def main():
-    zip_url = 'https://dist.torproject.org/torbrowser/7.0.8/tor-win32-0.3.1.7.zip'
+    zip_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.8/tor-win32-0.3.1.7.zip'
     zip_filename = 'tor-win32-0.3.1.7.zip'
     expected_zip_sha256 = 'fb4c330361d8a7449ed4b9a30848bdad47616166af64f7ace4c71ead83464780'
 


### PR DESCRIPTION
The install/build_osx.sh script is failing because Tor Project has removed the 6.5.2 release from https://dist.torproject.org/torbrowser/ so it 404s fetching the dmg.

This updates the version/filenames and associated signatures.

(I verified the packages against the GPG signing key, in order to have faith in the SHA256 sums, but I have no implicit trust in the key - I see you have signed Tor's signing key, so please double-check along with the SHA256 sums for safety)

This probably takes care of #454 and #448 for non-Linux users too..