### PR TITLE
#468 If the server is stopped before a download is completed, emit the Canceled message in the progress bar

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -376,9 +376,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         if self.new_download:
             self.vbar.setValue(self.vbar.maximum())
             self.new_download = False
-        # only check for requests if the server is running
-        if self.server_status.status != self.server_status.STATUS_STARTED:
-            return
 
         events = []
 
@@ -415,6 +412,9 @@ class OnionShareGui(QtWidgets.QMainWindow):
                     # close on finish?
                     if not web.get_stay_open():
                         self.server_status.stop_server()
+                else:
+                    if self.server_status.status == self.server_status.STATUS_STOPPED:
+                        self.downloads.cancel_download(event["data"]["id"])
 
             elif event["type"] == web.REQUEST_CANCELED:
                 self.downloads.cancel_download(event["data"]["id"])


### PR DESCRIPTION
Here's a fix for #468 but I'm not 100% sure on it.

The issue is that the server status only monitors progress/request activity if the server is running.

If a *receiving* user cancels their download of the file, the server is still running, and so the 'Canceled' message is updated in the Downloads progress bar accordingly.

But if the *sending* user stops the share before the user has finished downloading the file, there is no way to update the status bar as we have stopped polling and so we don't know the event ID (I think).

This fix removes the 'only check for requests if the server is running' condition, and sends the 'canceled download' message in the web.REQUEST_PROGRESS event if the download is not yet complete. If the server is stopped mid-download, the Download Progress bar just shows 'Canceled' just as if the receiver had canceled it.


An 'easier' fix would be to just hide the Downloads container on stop_server() but we might want to retain the visual history of previous completed downloads (perhaps especially if the user is allowing multiple downloads of the share without stopping).

I'm not sure if there's other implications of allowing check_for_requests to continue to run even if the server is stopped, maybe this early return() was put in there for a good reason (resource exhaustion?)