### PR TITLE
use LooseVersion instead of StrictVersion

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from distutils.version import StrictVersion as Version
+from distutils.version import LooseVersion as Version
 import queue, mimetypes, platform, os, sys, socket, logging, hmac
 from urllib.request import urlopen
 


### PR DESCRIPTION
Using LooseVersion means that upstream versions of Flask that contain -dev will still work OK (e.g for Arch Linux), whereas StrictVersion doesn't allow such a version suffix.

In my tests, this doesn't change any existing behavior so should be safe. The use of the dependency on StrictVersion was introduced in 406fffdb3969c96cd05ea643bfe1ec7f995afbb5 by garrettr purey for the purpose of this Flask  monkeypatch in the first place.

Fixes #442 and makes #465 obsolete.
