### PR TITLE
add missing arg to onion.connect() which broke the Tor Connection progress dialog (regression from b19f8fc)

### DIFF
--- a/onionshare_gui/tor_connection_dialog.py
+++ b/onionshare_gui/tor_connection_dialog.py
@@ -125,7 +125,7 @@ class TorConnectionThread(QtCore.QThread):
 
         # Connect to the Onion
         try:
-            self.onion.connect(self.settings, self._tor_status_update)
+            self.onion.connect(self.settings, False, self._tor_status_update)
             if self.onion.connected_to_tor:
                 self.connected_to_tor.emit()
             else:


### PR DESCRIPTION
In https://github.com/micahflee/onionshare/pull/437 we introduced support for passing an alternative config file, which changed some core functions by adding an extra arg.

One such is Onion.connect(). The Tor Connection progress dialog calls this function but the extra arg was missed from being added. The effect was that the bundled Tor progress dialog stayed at 0% even though it connected fine and the progress was shown in a console via print(). (I first noticed this bug in https://github.com/micahflee/onionshare/pull/469)

This adds the config arg to the onion.connect(), which I *think* is OK to be False here, but it's been a while since I worked on that change.

Sorry about the regression - I think this was introduced post-1.1 release, which is good at least.