### PR TITLE
Mentions python2 as the interpreter

### DIFF
--- a/install/scripts/onionshare-nautilus.py
+++ b/install/scripts/onionshare-nautilus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 import os
 import subprocess


### PR DESCRIPTION
`/usr/bin/env python` is  not anymore the preferred way to mention which Python interpreter we want to use. This fixes the corresponding rpmlint error.

```
onionshare.noarch: E: wrong-script-interpreter /usr/share/nautilus-python/extensions/onionshare-nautilus.py /usr/bin/env python
onionshare.noarch: E: non-executable-script /usr/share/nautilus-python/extensions/onionshare-nautilus.py 644 /usr/bin/env python
```