### PR TITLE
#431 Set minimum height of FileList to prevent resize bug affecting scrolling/visibility of bottom rows

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -35,6 +35,7 @@ class FileList(QtWidgets.QListWidget):
         self.setAcceptDrops(True)
         self.setIconSize(QtCore.QSize(32, 32))
         self.setSortingEnabled(True)
+        self.setMinimumHeight(200)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
         class DropHereLabel(QtWidgets.QLabel):


### PR DESCRIPTION
The issue described in #431 is broader than just the scrollbar disappearing, but also that in circumstances where the scrollbar *does* appear (Mac OS seems to force it?), the scrollbar does not let you see the very last rows, if the UI has been minimized too far.

IMO it makes sense to force a minimumHeight on the FileList widget, which seems to solve all such issues (for me at least).