### PR TITLE
#447 show alert and exit if the Settings dialog is canceled yet Tor is still not connected

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -505,7 +505,11 @@ class SettingsDialog(QtWidgets.QDialog):
         Cancel button clicked.
         """
         common.log('SettingsDialog', 'cancel_clicked')
-        self.close()
+        if not self.onion.connected_to_tor:
+            Alert(strings._('gui_tor_connection_canceled', True), QtWidgets.QMessageBox.Warning)
+            sys.exit()
+        else:
+            self.close()
 
     def help_clicked(self):
         """

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -112,5 +112,6 @@
     "gui_tor_connection_ask_open_settings": "Open Settings",
     "gui_tor_connection_ask_quit": "Quit",
     "gui_tor_connection_error_settings": "Try adjusting how OnionShare connects to the Tor network in Settings.",
+    "gui_tor_connection_canceled": "OnionShare is disconnected from Tor.\n\nPlease re-open OnionShare and configure the Tor connection.",
     "share_via_onionshare": "Share via OnionShare"
 }

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -112,6 +112,6 @@
     "gui_tor_connection_ask_open_settings": "Open Settings",
     "gui_tor_connection_ask_quit": "Quit",
     "gui_tor_connection_error_settings": "Try adjusting how OnionShare connects to the Tor network in Settings.",
-    "gui_tor_connection_canceled": "OnionShare is disconnected from Tor.\n\nPlease re-open OnionShare and configure the Tor connection.",
+    "gui_tor_connection_canceled": "OnionShare cannot connect to Tor.\n\nMake sure you're connected to the internet, then re-open OnionShare to configure the Tor connection.",
     "share_via_onionshare": "Share via OnionShare"
 }


### PR DESCRIPTION
Stopgap fix for #447 . 

I initially had it instead re-attempt the Tor connection dialog, but I found that if *that* dialog was canceled, it would return to the original behavior.

In this 'fix', if the user cancels the Tor connection dialog (or somehow Tor is not connected for some other reason), opens Settings, but cancels without making a change (thus not invoking a reload of settings and re-connection of Tor), an alert will be displayed that the user needs to reopen OnionShare. 

The app then exits, so you can't potentially attempt to start a share without a running Tor connection.

There is probably a better long term fix, so feel free to close this.