### PR TITLE
Don't uncheck the auto-stop timer when the FileList is updated

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -426,7 +426,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
                     # close on finish?
                     if not web.get_stay_open():
                         self.server_status.stop_server()
-                        self.server_status.shutdown_timeout_reset()
                         self.status_bar.showMessage(strings._('closing_automatically', True))
                 else:
                     if self.server_status.status == self.server_status.STATUS_STOPPED:
@@ -449,7 +448,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
                         if web.download_count == 0 or web.done:
                             self.server_status.stop_server()
                             self.status_bar.showMessage(strings._('close_on_timeout', True))
-                            self.server_status.shutdown_timeout_reset()
                         # A download is probably still running - hold off on stopping the share
                         else:
                             self.status_bar.showMessage(strings._('timeout_download_still_running', True))

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -119,6 +119,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         """
         Reset the timeout in the UI after stopping a share
         """
+        self.server_shutdown_timeout_checkbox.setCheckState(QtCore.Qt.Unchecked)
         self.server_shutdown_timeout.setDateTime(QtCore.QDateTime.currentDateTime().addSecs(300))
         self.server_shutdown_timeout.setMinimumDateTime(QtCore.QDateTime.currentDateTime().addSecs(120))
 
@@ -196,7 +197,6 @@ class ServerStatus(QtWidgets.QVBoxLayout):
                 self.start_server()
         elif self.status == self.STATUS_STARTED:
             self.stop_server()
-            self.shutdown_timeout_reset()
 
     def start_server(self):
         """
@@ -219,6 +219,7 @@ class ServerStatus(QtWidgets.QVBoxLayout):
         Stop the server.
         """
         self.status = self.STATUS_WORKING
+        self.shutdown_timeout_reset()
         self.update()
         self.server_stopped.emit()
 

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -163,7 +163,6 @@ class ServerStatus(QtWidgets.QVBoxLayout):
                 self.server_button.setText(strings._('gui_start_server', True))
                 self.server_shutdown_timeout.setEnabled(True)
                 self.server_shutdown_timeout_checkbox.setEnabled(True)
-                self.server_shutdown_timeout_checkbox.setCheckState(QtCore.Qt.Unchecked)
             elif self.status == self.STATUS_STARTED:
                 self.server_button.setEnabled(True)
                 self.server_button.setText(strings._('gui_stop_server', True))


### PR DESCRIPTION
Sorry @micahflee ,

I identified one UX issue with the shutdown timer checkbox.

Previously, I set the checkbox to be unchecked if the SERVER_STOPPED. This was done in the server_status.update function.

This was done so that when the server stops, the checkbox resets back to the default 'unchecked' mode, so that it isn't necessarily enabled by default for the next share.

However, I just discovered that the FileSelection widget triggers the server_status.update() function when the file list changes.

In other words, if you were to either:

1) set the timer *first* and *then* start adding files, or
2) add a file, set the timer, then add or remove a file

.. the timer checkbox would uncheck itself.

This fixes that, but also means that on subsequent new shares, the timer might retain its 'checked' mode - the user would have to uncheck that box if they don't want a timer on the next share. I think the former issue is more of a UX problem, so probably have to live with this extra step.

Hope that makes sense
