### PR TITLE
Raise an error if we were unable to obtain a random port

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -196,8 +196,8 @@ def get_available_port(min_port, max_port):
             try:
                 tmpsock.bind(("127.0.0.1", random.randint(min_port, max_port)))
                 break
-            except OSError:
-                pass
+            except OSError as e:
+                raise OSError(e)
         _, port = tmpsock.getsockname()
     return port
 

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -171,10 +171,16 @@ class Onion(object):
             if self.system == 'Windows':
                 # Windows needs to use network ports, doesn't support unix sockets
                 torrc_template = open(common.get_resource_path('torrc_template-windows')).read()
-                self.tor_control_port = common.get_available_port(1000, 65535)
+                try:
+                    self.tor_control_port = common.get_available_port(1000, 65535)
+                except:
+                    raise OSError(strings._('no_available_port'))
                 self.tor_control_socket = None
                 self.tor_cookie_auth_file = os.path.join(self.tor_data_directory.name, 'cookie')
-                self.tor_socks_port = common.get_available_port(1000, 65535)
+                try:
+                    self.tor_socks_port = common.get_available_port(1000, 65535)
+                except:
+                    raise OSError(strings._('no_available_port'))
                 self.tor_torrc = os.path.join(self.tor_data_directory.name, 'torrc')
             else:
                 # Linux and Mac can use unix sockets
@@ -183,7 +189,10 @@ class Onion(object):
                 self.tor_control_port = None
                 self.tor_control_socket = os.path.join(self.tor_data_directory.name, 'control_socket')
                 self.tor_cookie_auth_file = os.path.join(self.tor_data_directory.name, 'cookie')
-                self.tor_socks_port = common.get_available_port(1000, 65535)
+                try:
+                    self.tor_socks_port = common.get_available_port(1000, 65535)
+                except:
+                    raise OSError(strings._('no_available_port'))
                 self.tor_torrc = os.path.join(self.tor_data_directory.name, 'torrc')
 
             torrc_template = torrc_template.replace('{{data_directory}}',   self.tor_data_directory.name)

--- a/onionshare/onionshare.py
+++ b/onionshare/onionshare.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, shutil
 
-from . import common
+from . import common, strings
 
 class OnionShare(object):
     """
@@ -64,7 +64,10 @@ class OnionShare(object):
         common.log('OnionShare', 'start_onion_service')
 
         # Choose a random port
-        self.port = common.get_available_port(17600, 17650)
+        try:
+            self.port = common.get_available_port(17600, 17650)
+        except:
+            raise OSError(strings._('no_available_port'))
 
         if self.local_only:
             self.onion_host = '127.0.0.1:{0:d}'.format(self.port)
@@ -72,6 +75,7 @@ class OnionShare(object):
 
         if self.shutdown_timeout > 0:
             self.shutdown_timer = common.close_after_seconds(self.shutdown_timeout)
+
         self.onion_host = self.onion.start_onion_service(self.port)
 
         if self.stealth:

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -250,7 +250,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.app.start_onion_service()
                 self.starting_server_step2.emit()
 
-            except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorTimeout) as e:
+            except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorTimeout, OSError) as e:
                 self.starting_server_error.emit(e.args[0])
                 return
 
@@ -348,7 +348,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
         common.log('OnionShareGui', 'stop_server')
 
         if self.server_status.status != self.server_status.STATUS_STOPPED:
-            web.stop(self.app.port)
+            try:
+                web.stop(self.app.port)
+            except:
+                # Probably we had no port to begin with (Onion service didn't start)
+                pass
         self.app.cleanup()
         self.filesize_warning.hide()
         self.stop_server_finished.emit()

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -10,6 +10,7 @@
     "ctrlc_to_stop":  "Press Ctrl-C to stop server",
     "not_a_file": "{0:s} is not a file.",
     "not_a_readable_file": "{0:s} is not a readable file.",
+    "no_available_port": "Could not start the Onion service as we found no available port",
     "download_page_loaded": "Download page loaded",
     "other_page_loaded": "URL loaded",
     "close_on_timeout": "Closing automatically because timeout was reached",

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -10,7 +10,7 @@
     "ctrlc_to_stop":  "Press Ctrl-C to stop server",
     "not_a_file": "{0:s} is not a file.",
     "not_a_readable_file": "{0:s} is not a readable file.",
-    "no_available_port": "Could not start the Onion service as we found no available port",
+    "no_available_port": "Could not start the Onion service as there was no available port.",
     "download_page_loaded": "Download page loaded",
     "other_page_loaded": "URL loaded",
     "close_on_timeout": "Closing automatically because timeout was reached",


### PR DESCRIPTION
If all the available ports are in use, attempting to start the server just hangs forever in SERVER_WORKING state.

This fix wraps the attempt to get_available_port() so that it raises an exception if it can't obtain the port.

I think this might've been what led to #343 because I was able to see 'Configuring onion service on port 0' when the 'except' was just a 'pass'. (though I also see there are additional exceptions now to handle that Tor Connection issue, mentioning 'If you are using Whonix...' so that issue can probably just be closed now anyway.)


A simple PoC to use up the ports before attempting to start the share:

```
#!/bin/bash

for port in {17600..17650}; do
  nc -l $port &
done
```

You should now get an Alert in the UI when you attempt to Start Sharing.