### PR TITLE
cleanup the ephemeral hidden service when GUI server is stopped, but don't disconnect from Tor

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -415,7 +415,7 @@ class Onion(object):
 
         return onion_host
 
-    def cleanup(self):
+    def cleanup(self, stop_tor=True):
         """
         Stop onion services that were created earlier. If there's a tor subprocess running, kill it.
         """
@@ -429,25 +429,28 @@ class Onion(object):
                 pass
             self.service_id = None
 
-        # Stop tor process
-        if self.tor_proc:
-            self.tor_proc.terminate()
-            time.sleep(0.2)
-            if not self.tor_proc.poll():
-                self.tor_proc.kill()
-            self.tor_proc = None
+        if stop_tor:
+            # Stop tor process
+            if self.tor_proc:
+                self.tor_proc.terminate()
+                time.sleep(0.2)
+                if not self.tor_proc.poll():
+                    try:
+                        self.tor_proc.kill()
+                    except:
+                        pass
+                self.tor_proc = None
 
-        # Reset other Onion settings
-        self.connected_to_tor = False
-        self.stealth = False
-        self.service_id = None
+            # Reset other Onion settings
+            self.connected_to_tor = False
+            self.stealth = False
 
-        try:
-            # Delete the temporary tor data directory
-            self.tor_data_directory.cleanup()
-        except AttributeError:
-            # Skip if cleanup was somehow run before connect
-            pass
+            try:
+                # Delete the temporary tor data directory
+                self.tor_data_directory.cleanup()
+            except AttributeError:
+                # Skip if cleanup was somehow run before connect
+                pass
 
     def get_tor_socks_port(self):
         """

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -354,6 +354,8 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 # Probably we had no port to begin with (Onion service didn't start)
                 pass
         self.app.cleanup()
+        # Remove ephemeral service, but don't disconnect from Tor
+        self.onion.cleanup(stop_tor=False)
         self.filesize_warning.hide()
         self.stop_server_finished.emit()
 


### PR DESCRIPTION
As mentioned in #485:

When the server is stopped via the GUI, it does not fire Onion.cleanup(). So technically the ephemeral hidden service remains in the Stem connection (doing nothing, because the web server is stopped).

But the Onion.cleanup() is too severe a cleanup: it kills the whole Tor connection.

This change introduces an optional parameter 'stop_tor' to Onion.cleanup() (defaulting to True). If False, it will just remove the ephemeral service, but leave Tor connected.

This allows us to remove the ephemeral service when the share is stopped via the UI, while also allowing us to start a new share (because Tor is still connected).

This is crucial for starting a new share with the same private key (#485) otherwise Stem will complain there is an address collision (the previous ephemeral service is still lingering)