### PR TITLE
Nautilus extension: avoid spamming the logs due to missing method.

### DIFF
--- a/install/scripts/onionshare-nautilus.py
+++ b/install/scripts/onionshare-nautilus.py
@@ -93,3 +93,7 @@ class OnionShareExtension(GObject.GObject, Nautilus.MenuProvider):
         for file in files:
             file_list.append(self.url2path(file))
         self.exec_onionshare(file_list)
+
+    # Workaround https://bugzilla.gnome.org/show_bug.cgi?id=784278
+    def get_background_items(self, window, file):
+        return None


### PR DESCRIPTION
Without this change I see a dozen or so warnings in the Journal:

    nautilus_menu_provider_get_background_items: assertion
    'NAUTILUS_IS_MENU_PROVIDER (provider)' failed

Nautilus upstream developers are going to discuss if/how they want to address
this on their side; in the meantime they recommend simply adding a no-op method
to silence the logs, so here we go.

FWIW this is also tracked as Tails bug https://labs.riseup.net/code/issues/13174