### PR TITLE
Upgrade Windows and Mac version of bundled Tor to 0.3.1.8

### DIFF
--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, zipfile, io, shutil, subprocess
 import urllib.request
 
 def main():
-    dmg_url = 'https://www.torproject.org/dist/torbrowser/6.5.2/TorBrowser-6.5.2-osx64_en-US.dmg'
-    dmg_filename = 'TorBrowser-6.5.2-osx64_en-US.dmg'
-    expected_dmg_sha256 = '0b11d12f9ff0d82ceb2a9a4dba9c4ba234da47640c8e25e76e4092a7d3a90ef6'
+    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.10/TorBrowser-7.0.10-osx64_en-US.dmg'
+    dmg_filename = 'TorBrowser-7.0.10-osx64_en-US.dmg'
+    expected_dmg_sha256 = '2de32de962d14ecb55f8008078875f3d0b0875dba4a140726714e67ce329fe9a'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))

--- a/install/get-tor-windows.py
+++ b/install/get-tor-windows.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, zipfile, io, shutil
 import urllib.request
 
 def main():
-    zip_url = 'https://www.torproject.org/dist/torbrowser/6.5.1/tor-win32-0.2.9.10.zip'
-    zip_filename = 'tor-win32-0.2.9.10.zip'
-    expected_zip_sha256 = '56e639cd73c48f383fd638568e01ca07750211fca79c87e668cf8baccbf9d38a'
+    zip_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.10/tor-win32-0.3.1.8.zip'
+    zip_filename = 'tor-win32-0.3.1.8.zip'
+    expected_zip_sha256 = '101defd239cda42f364815e91809fad16b17f03843a169ffbeb8cb91183b6ba8'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))


### PR DESCRIPTION
Upgrade to tor to 0.3.18. This is a newer version that in #469 so that PR isn't necessary (thanks anyway @mig5). Tested in Windows and macOS.