### PR TITLE
#493 check the Tor connection is still working before attempting to start the server

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -375,6 +375,14 @@ class Onion(object):
             # ephemeral stealth onion services are not supported
             self.supports_stealth = False
 
+
+    def is_authenticated(self):
+        """
+        Returns True if the Tor connection is still working, or False otherwise.
+        """
+        return self.c.is_authenticated()
+
+
     def start_onion_service(self, port):
         """
         Start a onion service on port 80, pointing to the given port, and

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -219,6 +219,15 @@ class OnionShareGui(QtWidgets.QMainWindow):
         def reload_settings():
             common.log('OnionShareGui', 'open_settings', 'settings have changed, reloading')
             self.settings.load()
+            # Check if we're not yet connected to Tor (user might've opened Tor Browser
+            # whilst the SettingsDialog was opened). If not, try and connect once more.
+            # If we still can't connect, abort entirely.
+            if not self.onion.is_authenticated():
+                try:
+                    self.onion.connect(self.settings, False)
+                 except:
+                    Alert(strings._('gui_tor_connection_canceled', True), QtWidgets.QMessageBox.Warning)
+                    sys.exit()
 
         d = SettingsDialog(self.onion, self.qtapp, self.config)
         d.settings_saved.connect(reload_settings)
@@ -234,7 +243,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         # Check we're still connected to Tor
         if not self.onion.is_authenticated():
             self.start_server_error(strings._('error_tor_protocol_error'))
-            sys.exit()
+            self._tor_connection_canceled()
 
         self.set_server_active(True)
 

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -231,6 +231,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
         """
         common.log('OnionShareGui', 'start_server')
 
+        # Check we're still connected to Tor
+        if not self.onion.is_authenticated():
+            self.start_server_error(strings._('error_tor_protocol_error'))
+            sys.exit()
+
         self.set_server_active(True)
 
         self.app.set_stealth(self.settings.get('use_stealth'))

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -225,7 +225,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
             if not self.onion.is_authenticated():
                 try:
                     self.onion.connect(self.settings, False)
-                 except:
+                except:
                     Alert(strings._('gui_tor_connection_canceled', True), QtWidgets.QMessageBox.Warning)
                     sys.exit()
 

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -244,11 +244,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         """
         common.log('OnionShareGui', 'start_server')
 
-        # Check we're still connected to Tor
-        if not self.onion.is_authenticated():
-            self.start_server_error(strings._('error_tor_protocol_error'))
-            self._tor_connection_canceled()
-
         self.set_server_active(True)
 
         self.app.set_stealth(self.settings.get('use_stealth'))


### PR DESCRIPTION
Fix for #493 

New helper function Onion.is_authenticated() (we can't rely on self.onion.connected_to_tor here because it's still set to True from the previously-working connection, even if Tor Browser has been closed).

Previously I just threw a sys.exit() after alerting, but realised we can present the opportunity to the user to fix the situation without closing the app, so added another commit. 

Now, if not connected to Tor when clicking Start Server, we alert and offer the ability to edit the Tor connection settings (open the SettingsDialog). When saving the Settings, check if we're still not connected to Tor, and if not, attempt again to reconnect. The scenario I'm accounting for here is as follows:

1) Start Tor Browser
2) Open OnionShare, configured to rely on Tor Browser rather than bundled
3) Start a share
4) Close Tor Browser
5) Stop share
6) Start a share (rather than hang forever in SERVER_WORKING, you will now receive an alert and the offer to open SettingsDialog)
7) Start Tor Browser
8) Save Settings (we will now try and reconnect to Tor (successfully, because you re-opened Tor Browser))
9) Start a share (this will now succeed)

If you repeat as above but skip step 7, OnionShare will give up, alert the user and exit, since it could still not obtain a connection. (similar to #447)



Other bits of functionality such as UpdateChecker() could probably now also benefit from the Onion.is_authenticated() conditional, and maybe more generally phase out the self.onion.connected_to_tor boolean (or we could re-save that boolean as True in this new function).