### PR TITLE
Catch OSError when preparing the zip file during server start.

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -287,12 +287,16 @@ class OnionShareGui(QtWidgets.QMainWindow):
             def _set_processed_size(x):
                 if self._zip_progress_bar != None:
                     self._zip_progress_bar.update_processed_size_signal.emit(x)
-            web.set_file_info(self.file_selection.file_list.filenames, processed_size_callback=_set_processed_size)
-            self.app.cleanup_filenames.append(web.zip_filename)
-            self.starting_server_step3.emit()
+            try:
+                web.set_file_info(self.file_selection.file_list.filenames, processed_size_callback=_set_processed_size)
+                self.app.cleanup_filenames.append(web.zip_filename)
+                self.starting_server_step3.emit()
 
-            # done
-            self.start_server_finished.emit()
+                # done
+                self.start_server_finished.emit()
+            except OSError as e:
+                self.starting_server_error.emit(e.strerror)
+                return
 
         #self.status_bar.showMessage(strings._('gui_starting_server2', True))
         t = threading.Thread(target=finish_starting_server, kwargs={'self': self})
@@ -339,6 +343,9 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         Alert(error, QtWidgets.QMessageBox.Warning)
         self.server_status.stop_server()
+        if self._zip_progress_bar is not None:
+            self.status_bar.removeWidget(self._zip_progress_bar)
+            self._zip_progress_bar = None
         self.status_bar.clearMessage()
 
     def stop_server(self):


### PR DESCRIPTION
Fixes #453

If the disk fills up during the start of the share, an alert will display with the OSError (likely 'No space left on device') and the server will fail in the proper way.

I also remove the progress bar widget in OnionShareGui.start_server_error(), if it was present. This clears the 'Crunching files: 0%' when the server fails to start.

The way I tested this was in my Onionshare dev AppVM as follows:

1) fallocate -l 9GB /tmp/out (fill up the main filesystem of the AppVM)
2) Create a large file in home dir (I used dd if=/dev/urandom of=~/foo.. with a file of about 300MB, because I wanted something that didn't compress instantly due to being full of zeroes)
3) Start OnionShare (this actually works OK, because Python's tmp dir creation falls back to using the home dir after it realises the AppVM's / is full)
4) Fill up the remaining space in the user /rw (fallocate -l 2GB /rw/home/user/out, or whatever size is free in your home dir)
5) Share the ~/foo file

It should fail at 'Crunching files' step and throw an Alert dialog 'No space left on device'


P.S this is a non-issue for the CLI version as it exits expectedly on the underlying OSError. So basically this is just another of those cases where the GUI loses its IPC with any low-level exceptions from the Onionshare/Onion/Web modules (like #484 and #494)