### PR TITLE
#493, #500 - detect if the Tor connection (bundled, TorBrowser or otherwise) has been lost while the app is open. Stop a running share if so

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -380,7 +380,7 @@ class Onion(object):
         """
         Returns True if the Tor connection is still working, or False otherwise.
         """
-        if self.c:
+        if self.c is not None:
             return self.c.is_authenticated()
         else:
             return False

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -375,11 +375,16 @@ class Onion(object):
             # ephemeral stealth onion services are not supported
             self.supports_stealth = False
 
+
     def is_authenticated(self):
         """
         Returns True if the Tor connection is still working, or False otherwise.
         """
-        return self.c.is_authenticated()
+        if self.c:
+            return self.c.is_authenticated()
+        else:
+            return False
+
 
     def start_onion_service(self, port):
         """

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -375,6 +375,12 @@ class Onion(object):
             # ephemeral stealth onion services are not supported
             self.supports_stealth = False
 
+    def is_authenticated(self):
+        """
+        Returns True if the Tor connection is still working, or False otherwise.
+        """
+        return self.c.is_authenticated()
+
     def start_onion_service(self, port):
         """
         Start a onion service on port 80, pointing to the given port, and

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -176,7 +176,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         quit, or open settings.
         """
         common.log('OnionShareGui', '_tor_connection_canceled')
-        self.timer.stop()
 
         def ask():
             a = Alert(strings._('gui_tor_connection_ask', True), QtWidgets.QMessageBox.Question, buttons=QtWidgets.QMessageBox.NoButton, autostart=False)
@@ -223,8 +222,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
             # We might've stopped the main requests timer if a Tor connection failed.
             # If we've reloaded settings, we probably succeeded in obtaining a new
             # connection. If so, restart the timer.
-            if not self.timer.isActive():
-                self.timer.start()
+            if self.onion.is_authenticated():
+                if not self.timer.isActive():
+                    self.timer.start()
+                    self.status_bar.clearMessage()
 
         d = SettingsDialog(self.onion, self.qtapp, self.config)
         d.settings_saved.connect(reload_settings)
@@ -401,8 +402,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.timer.stop()
                 if self.server_status.status != self.server_status.STATUS_STOPPED:
                     self.server_status.stop_server()
-                    self.status_bar.clearMessage()
-                self._tor_connection_canceled()
+                self.status_bar.showMessage(strings._('gui_tor_connection_lost', True))
 
         # scroll to the bottom of the dl progress bar log pane
         # if a new download has been added

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -142,10 +142,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.set_server_active(False)
 
         # Start the "Connecting to Tor" dialog, which calls onion.connect()
-        tor_con = TorConnectionDialog(self.qtapp, self.settings, self.onion)
-        tor_con.canceled.connect(self._tor_connection_canceled)
-        tor_con.open_settings.connect(self._tor_connection_open_settings)
-        tor_con.start()
+        self.tor_con = TorConnectionDialog(self.qtapp, self.settings, self.onion)
+        self.tor_con.canceled.connect(self._tor_connection_canceled)
+        self.tor_con.open_settings.connect(self._tor_connection_open_settings)
+        self.tor_con.start()
 
         # After connecting to Tor, check for updates
         self.check_for_updates()
@@ -394,17 +394,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
         """
         self.update()
 
-        # Have we lost connection to Tor somehow?
-        try:
-            # Tor Browser may not even have been open when we started OnionShare,
-            # in which case onion.is_authenticated() throws a NoneType error
-            self.onion
-            if not self.onion.is_authenticated():
-                self.timer.stop()
-                self.start_server_error(strings._('error_tor_protocol_error'))
-                self._tor_connection_canceled()
-        except:
-            pass
+        # Has the Tor Connection dialog finished, but we've since lost connection to Tor somehow?
+        if not self.onion.is_authenticated() and self.tor_con.t.isFinished():
+            self.timer.stop()
+            self.start_server_error(strings._('error_tor_protocol_error'))
+            self._tor_connection_canceled()
 
         # scroll to the bottom of the dl progress bar log pane
         # if a new download has been added

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -225,7 +225,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
             if self.onion.is_authenticated():
                 if not self.timer.isActive():
                     self.timer.start()
-                    self.status_bar.clearMessage()
+                # If there were some files listed for sharing, we should be ok to
+                # re-enable the 'Start Sharing' button now.
+                if self.server_status.file_selection.get_num_files() > 0:
+                    self.server_status.server_button.setEnabled(True)
+                self.status_bar.clearMessage()
 
         d = SettingsDialog(self.onion, self.qtapp, self.config)
         d.settings_saved.connect(reload_settings)
@@ -402,6 +406,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.timer.stop()
                 if self.server_status.status != self.server_status.STATUS_STOPPED:
                     self.server_status.stop_server()
+                self.server_status.server_button.setEnabled(False)
                 self.status_bar.showMessage(strings._('gui_tor_connection_lost', True))
 
         # scroll to the bottom of the dl progress bar log pane

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -408,6 +408,8 @@ class OnionShareGui(QtWidgets.QMainWindow):
                     self.server_status.stop_server()
                 self.server_status.server_button.setEnabled(False)
                 self.status_bar.showMessage(strings._('gui_tor_connection_lost', True))
+                if self.systemTray.supportsMessages() and self.settings.get('systray_notifications'):
+                    self.systemTray.showMessage(strings._('gui_tor_connection_lost', True), strings._('gui_tor_connection_error_settings', True))
 
         # scroll to the bottom of the dl progress bar log pane
         # if a new download has been added

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -459,31 +459,26 @@ class SettingsDialog(QtWidgets.QDialog):
         # If Tor isn't connected, or if Tor settings have changed, Reinitialize
         # the Onion object
         reboot_onion = False
-        try:
-            self.onion
-            if self.onion.is_authenticated():
-                def changed(s1, s2, keys):
-                    """
-                    Compare the Settings objects s1 and s2 and return true if any values
-                    have changed for the given keys.
-                    """
-                    for key in keys:
-                        if s1.get(key) != s2.get(key):
-                            return True
-                    return False
+        if self.onion.is_authenticated():
+            def changed(s1, s2, keys):
+                """
+                Compare the Settings objects s1 and s2 and return true if any values
+                have changed for the given keys.
+                """
+                for key in keys:
+                    if s1.get(key) != s2.get(key):
+                        return True
+                return False
 
-                if changed(settings, self.old_settings, [
-                    'connection_type', 'control_port_address',
-                    'control_port_port', 'socks_address', 'socks_port',
-                    'socket_file_path', 'auth_type', 'auth_password']):
+            if changed(settings, self.old_settings, [
+                'connection_type', 'control_port_address',
+                'control_port_port', 'socks_address', 'socks_port',
+                'socket_file_path', 'auth_type', 'auth_password']):
 
-                    reboot_onion = True
-
-            else:
-                # Tor isn't connected, so try connecting
                 reboot_onion = True
-        except:
-            # We definitely aren't connected, as the onion object had no attribute is_authenticated()
+
+        else:
+            # Tor isn't connected, so try connecting
             reboot_onion = True
 
         # Do we need to reinitialize Tor?
@@ -497,7 +492,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
             common.log('SettingsDialog', 'save_clicked', 'Onion done rebooting, connected to Tor: {}'.format(self.onion.connected_to_tor))
 
-            if self.onion.connected_to_tor and not tor_con.wasCanceled():
+            if self.onion.is_authenticated() and not tor_con.wasCanceled():
                 self.settings_saved.emit()
                 self.close()
 
@@ -510,7 +505,7 @@ class SettingsDialog(QtWidgets.QDialog):
         Cancel button clicked.
         """
         common.log('SettingsDialog', 'cancel_clicked')
-        if not self.onion.connected_to_tor:
+        if not self.onion.is_authenticated():
             Alert(strings._('gui_tor_connection_canceled', True), QtWidgets.QMessageBox.Warning)
             sys.exit()
         else:
@@ -565,7 +560,7 @@ class SettingsDialog(QtWidgets.QDialog):
         common.log('SettingsDialog', 'closeEvent')
 
         # On close, if Tor isn't connected, then quit OnionShare altogether
-        if not self.onion.connected_to_tor:
+        if not self.onion.is_authenticated():
             common.log('SettingsDialog', 'closeEvent', 'Closing while not connected to Tor')
 
             # Wait 1ms for the event loop to finish, then quit

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -459,26 +459,31 @@ class SettingsDialog(QtWidgets.QDialog):
         # If Tor isn't connected, or if Tor settings have changed, Reinitialize
         # the Onion object
         reboot_onion = False
-        if self.onion.connected_to_tor:
-            def changed(s1, s2, keys):
-                """
-                Compare the Settings objects s1 and s2 and return true if any values
-                have changed for the given keys.
-                """
-                for key in keys:
-                    if s1.get(key) != s2.get(key):
-                        return True
-                return False
+        try:
+            self.onion
+            if self.onion.is_authenticated():
+                def changed(s1, s2, keys):
+                    """
+                    Compare the Settings objects s1 and s2 and return true if any values
+                    have changed for the given keys.
+                    """
+                    for key in keys:
+                        if s1.get(key) != s2.get(key):
+                            return True
+                    return False
 
-            if changed(settings, self.old_settings, [
-                'connection_type', 'control_port_address',
-                'control_port_port', 'socks_address', 'socks_port',
-                'socket_file_path', 'auth_type', 'auth_password']):
+                if changed(settings, self.old_settings, [
+                    'connection_type', 'control_port_address',
+                    'control_port_port', 'socks_address', 'socks_port',
+                    'socket_file_path', 'auth_type', 'auth_password']):
 
+                    reboot_onion = True
+
+            else:
+                # Tor isn't connected, so try connecting
                 reboot_onion = True
-
-        else:
-            # Tor isn't connected, so try connecting
+        except:
+            # We definitely aren't connected, as the onion object had no attribute is_authenticated()
             reboot_onion = True
 
         # Do we need to reinitialize Tor?

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -460,6 +460,7 @@ class SettingsDialog(QtWidgets.QDialog):
         # the Onion object
         reboot_onion = False
         if self.onion.is_authenticated():
+            common.log('SettingsDialog', 'save_clicked', 'Connected to Tor')
             def changed(s1, s2, keys):
                 """
                 Compare the Settings objects s1 and s2 and return true if any values
@@ -478,6 +479,7 @@ class SettingsDialog(QtWidgets.QDialog):
                 reboot_onion = True
 
         else:
+            common.log('SettingsDialog', 'save_clicked', 'Not connected to Tor')
             # Tor isn't connected, so try connecting
             reboot_onion = True
 

--- a/onionshare_gui/tor_connection_dialog.py
+++ b/onionshare_gui/tor_connection_dialog.py
@@ -86,6 +86,7 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
     def _canceled_connecting_to_tor(self):
         common.log('TorConnectionDialog', '_canceled_connecting_to_tor')
         self.active = False
+        self.onion.cleanup()
 
         # Cancel connecting to Tor
         QtCore.QTimer.singleShot(1, self.cancel)
@@ -126,7 +127,7 @@ class TorConnectionThread(QtCore.QThread):
         # Connect to the Onion
         try:
             self.onion.connect(self.settings, False, self._tor_status_update)
-            if self.onion.is_authenticated():
+            if self.onion.connected_to_tor:
                 self.connected_to_tor.emit()
             else:
                 self.canceled_connecting_to_tor.emit()

--- a/onionshare_gui/tor_connection_dialog.py
+++ b/onionshare_gui/tor_connection_dialog.py
@@ -57,12 +57,12 @@ class TorConnectionDialog(QtWidgets.QProgressDialog):
     def start(self):
         common.log('TorConnectionDialog', 'start')
 
-        t = TorConnectionThread(self, self.settings, self.onion)
-        t.tor_status_update.connect(self._tor_status_update)
-        t.connected_to_tor.connect(self._connected_to_tor)
-        t.canceled_connecting_to_tor.connect(self._canceled_connecting_to_tor)
-        t.error_connecting_to_tor.connect(self._error_connecting_to_tor)
-        t.start()
+        self.t = TorConnectionThread(self, self.settings, self.onion)
+        self.t.tor_status_update.connect(self._tor_status_update)
+        self.t.connected_to_tor.connect(self._connected_to_tor)
+        self.t.canceled_connecting_to_tor.connect(self._canceled_connecting_to_tor)
+        self.t.error_connecting_to_tor.connect(self._error_connecting_to_tor)
+        self.t.start()
 
         # The main thread needs to remain active, and checkign for Qt events,
         # until the thread is finished. Otherwise it won't be able to handle
@@ -126,7 +126,7 @@ class TorConnectionThread(QtCore.QThread):
         # Connect to the Onion
         try:
             self.onion.connect(self.settings, False, self._tor_status_update)
-            if self.onion.connected_to_tor:
+            if self.onion.is_authenticated():
                 self.connected_to_tor.emit()
             else:
                 self.canceled_connecting_to_tor.emit()

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -114,11 +114,12 @@
     "update_error_check_error": "Error checking for updates: Maybe you're not connected to Tor, or maybe the OnionShare website is down.",
     "update_error_invalid_latest_version": "Error checking for updates: The OnionShare website responded saying the latest version is '{}', but that doesn't appear to be a valid version string.",
     "update_not_available": "You are running the latest version of OnionShare.",
-    "gui_tor_connection_ask": "Tor isn't running.\n\nWould you like to open OnionShare settings to troubleshoot connecting to Tor?",
+    "gui_tor_connection_ask": "Would you like to open OnionShare settings to troubleshoot connecting to Tor?",
     "gui_tor_connection_ask_open_settings": "Open Settings",
     "gui_tor_connection_ask_quit": "Quit",
     "gui_tor_connection_error_settings": "Try adjusting how OnionShare connects to the Tor network in Settings.",
     "gui_tor_connection_canceled": "OnionShare cannot connect to Tor.\n\nMake sure you're connected to the internet, then re-open OnionShare to configure the Tor connection.",
+    "gui_tor_connection_lost": "Disconnected from Tor.",
     "gui_server_started_after_timeout": "The server started after your chosen auto-timeout.\nPlease start a new share.",
     "gui_server_timeout_expired": "The chosen timeout has already expired.\nPlease update the timeout and then you may start sharing.",
     "share_via_onionshare": "Share via OnionShare"

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -114,7 +114,7 @@
     "update_error_check_error": "Error checking for updates: Maybe you're not connected to Tor, or maybe the OnionShare website is down.",
     "update_error_invalid_latest_version": "Error checking for updates: The OnionShare website responded saying the latest version is '{}', but that doesn't appear to be a valid version string.",
     "update_not_available": "You are running the latest version of OnionShare.",
-    "gui_tor_connection_ask": "Would you like to open OnionShare settings to troubleshoot connecting to Tor?",
+    "gui_tor_connection_ask": "Tor isn't running.\n\nWould you like to open OnionShare settings to troubleshoot connecting to Tor?",
     "gui_tor_connection_ask_open_settings": "Open Settings",
     "gui_tor_connection_ask_quit": "Quit",
     "gui_tor_connection_error_settings": "Try adjusting how OnionShare connects to the Tor network in Settings.",


### PR DESCRIPTION
A re-implementation of https://github.com/micahflee/onionshare/pull/494 which is hopefully accounting for all weird edge cases and the issues #493 and #500.

@Baccount I would love some testing of this (no pressure though) with both Tor Browser and 'Bundled Tor' modes. You can kill Bundled Tor by running 'pkill -f tor.real' from a terminal while the app is open, and you should get the same alert as when you close Tor Browser when using that mode.