### PR TITLE
Emit the files_updated signal when deleting files. This will ensure that the share button gets disabled when there are no files in the list

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -229,6 +229,7 @@ class FileSelection(QtWidgets.QVBoxLayout):
             itemrow = self.file_list.row(item)
             self.file_list.filenames.pop(itemrow)
             self.file_list.takeItem(itemrow)
+        self.file_list.files_updated.emit()
         self.update()
 
     def server_started(self):


### PR DESCRIPTION
I discovered that if you added N files in the GUI (thus triggering the emitted signal that enables the Share button) but then deleted all the files in the GUI, the Share button remained enabled.

This allowed the user to actually start a share, with an empty zip file.

```
user@host:~/.tb/tor-browser/Browser/Downloads$ unzip onionshare_vsprqm.zip 
Archive:  onionshare_vsprqm.zip
warning [onionshare_vsprqm.zip]:  zipfile is empty
```

This change emits the signal so that the relevant check in ServerStatus is triggered when files are deleted from the list (not just added)