### PR TITLE
Increasing the timeout

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -254,8 +254,8 @@ class Onion(object):
                     break
                 time.sleep(0.2)
 
-                # Timeout after 45 seconds
-                if time.time() - start_ts > 45:
+                # Timeout after 90 seconds
+                if time.time() - start_ts > 90:
                     print("")
                     self.tor_proc.terminate()
                     raise BundledTorTimeout(strings._('settings_error_bundled_tor_timeout'))


### PR DESCRIPTION
I have had times where the bootstrap has taken around 80 seconds so I set it to 90 seconds just to be safe. Please correct the time if you thing that timeout is too long. Thank you @mig5 , lets see if this works. #508