### PR TITLE
#520 trigger browser action properly in QLabel hyperlink

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -72,6 +72,8 @@ class SettingsDialog(QtWidgets.QDialog):
         # Stealth
         stealth_details = QtWidgets.QLabel(strings._("gui_settings_stealth_option_details", True))
         stealth_details.setWordWrap(True)
+        stealth_details.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+        stealth_details.setOpenExternalLinks(True)
         self.stealth_checkbox = QtWidgets.QCheckBox()
         self.stealth_checkbox.setCheckState(QtCore.Qt.Unchecked)
         self.stealth_checkbox.setText(strings._("gui_settings_stealth_option", True))


### PR DESCRIPTION
Fixes #520 

Taken from https://stackoverflow.com/questions/8427446/making-qlabel-behave-like-a-hyperlink

At this time, the only other widget that contains a hyperlink in strings() is 'update_available' - that's an Alert dialog rather than a Qlabel, and there is of course no update available, so it's hard to test if that dialog needs a similar fix or is immune (e.g whether it's QLabel specific). 

Note that in my 'support bridges' PR there is a similar QLabel with a hyperlink, so will need a similar fix if merged..