### PR TITLE
#528 disable the 'Check for Updates' button in the SettingsDialog if Tor is not connected

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -96,6 +96,9 @@ class SettingsDialog(QtWidgets.QDialog):
         # Check for updates button
         self.check_for_updates_button = QtWidgets.QPushButton(strings._('gui_settings_autoupdate_check_button', True))
         self.check_for_updates_button.clicked.connect(self.check_for_updates)
+        # We can't check for updates if not connected to Tor
+        if not self.onion.connected_to_tor:
+            self.check_for_updates_button.setEnabled(False)
 
         # Autoupdate options layout
         autoupdate_group_layout = QtWidgets.QVBoxLayout()

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -596,8 +596,11 @@ class SettingsDialog(QtWidgets.QDialog):
 
     def _enable_buttons(self):
         common.log('SettingsDialog', '_enable_buttons')
-
-        self.check_for_updates_button.setEnabled(True)
+        # We can't check for updates if we're still not connected to Tor
+        if not self.onion.connected_to_tor:
+            self.check_for_updates_button.setEnabled(False)
+        else:
+            self.check_for_updates_button.setEnabled(True)
         self.connection_type_test_button.setEnabled(True)
         self.save_button.setEnabled(True)
         self.cancel_button.setEnabled(True)


### PR DESCRIPTION
No major harm, but no sense in allowing the user to click the Updates button if their Tor connection failed to succeed (which might be why they've landed on the SettingsDialog in the first place)

Probably is the cause of #528 