### PR TITLE
Bump pyinstaller requirements version

### DIFF
--- a/install/requirements-windows.txt
+++ b/install/requirements-windows.txt
@@ -5,7 +5,7 @@ itsdangerous==0.24
 Jinja2==2.9.5
 MarkupSafe==0.23
 pefile==2016.3.28
-PyInstaller==3.2.1
+PyInstaller==3.3.1
 pypiwin32==219
 PyQt5==5.8
 PySocks==1.6.7

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -3,7 +3,7 @@ Flask==0.12
 itsdangerous==0.24
 Jinja2==2.9.5
 MarkupSafe==0.23
-PyInstaller==3.2.1
+PyInstaller==3.3.1
 PyQt5==5.7.1
 PySocks==1.6.7
 sip==4.19


### PR DESCRIPTION
This fixes #451 and #533, @micahflee please compile the final macOS app with pyinstaller 3.3.1 to fix the bugs.