### PR TITLE
Update the check_lacked_trans.py script to work with latest codebase

### DIFF
--- a/install/check_lacked_trans.py
+++ b/install/check_lacked_trans.py
@@ -36,7 +36,9 @@ def arg_parser():
     p.add_argument('-d', default='.', help='onionshare directory',
                    metavar='ONIONSHARE_DIR', dest='onionshare_dir')
     p.add_argument('--show-all-keys', action='store_true',
-                   help='show translation key in source and exit')
+                   help='show translation key in source and exit'),
+    p.add_argument('-l', default='all', help='language code (default: all)',
+                   metavar='LANG_CODE', dest='lang_code')
     return p
 
 
@@ -55,6 +57,8 @@ def main():
     src = files_in(dir, 'onionshare') + files_in(dir, 'onionshare_gui')
     pysrc = [p for p in src if p.endswith('.py')]
 
+    lang_code = args.lang_code
+
     translate_keys = set()
     # load translate key from python source
     for line in fileinput.input(pysrc, openhook=fileinput.hook_encoded('utf-8')):
@@ -71,7 +75,10 @@ def main():
             print(k)
         sys.exit()
 
-    locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json')]
+    if lang_code == 'all':
+        locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json')]
+    else:
+        locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json') and lang_code in f]
     for locale_file in locale_files:
         with codecs.open(locale_file, 'r', encoding='utf-8') as f:
             trans = json.load(f)

--- a/install/check_lacked_trans.py
+++ b/install/check_lacked_trans.py
@@ -78,7 +78,7 @@ def main():
     if lang_code == 'all':
         locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json')]
     else:
-      locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('%s.json' % lang_code)]
+        locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('%s.json' % lang_code)]
     for locale_file in locale_files:
         with codecs.open(locale_file, 'r', encoding='utf-8') as f:
             trans = json.load(f)

--- a/install/check_lacked_trans.py
+++ b/install/check_lacked_trans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -54,7 +54,6 @@ def main():
 
     src = files_in(dir, 'onionshare') + files_in(dir, 'onionshare_gui')
     pysrc = [p for p in src if p.endswith('.py')]
-    htmlsrc = [p for p in src if p.endswith('.html')]
 
     translate_keys = set()
     # load translate key from python source
@@ -67,20 +66,12 @@ def main():
             key = arg.split(',')[0].strip('''"' ''')
             translate_keys.add(key)
 
-    # load translate key from html source
-    for line in fileinput.input(htmlsrc, openhook=fileinput.hook_encoded('utf-8')):
-        # search `{{strings.translate_key}}`
-        m = re.search(r'{{.*strings\.([-a-zA-Z0-9_]+).*}}', line)
-        if m:
-            key = m.group(1)
-            translate_keys.add(key)
-
     if args.show_all_keys:
         for k in sorted(translate_keys):
-            print k
+            print(k)
         sys.exit()
 
-    locale_files = [f for f in files_in(dir, 'locale') if f.endswith('.json')]
+    locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json')]
     for locale_file in locale_files:
         with codecs.open(locale_file, 'r', encoding='utf-8') as f:
             trans = json.load(f)
@@ -92,10 +83,10 @@ def main():
 
         locale, ext = os.path.splitext(os.path.basename(locale_file))
         for k in sorted(disused):
-            print locale, 'disused', k
+            print(locale, 'disused', k)
 
         for k in sorted(lacked):
-            print locale, 'lacked', k
+            print(locale, 'lacked', k)
 
 
 if __name__ == '__main__':

--- a/install/check_lacked_trans.py
+++ b/install/check_lacked_trans.py
@@ -78,7 +78,7 @@ def main():
     if lang_code == 'all':
         locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json')]
     else:
-        locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('.json') and lang_code in f]
+      locale_files = [f for f in files_in(dir, 'share/locale') if f.endswith('%s.json' % lang_code)]
     for locale_file in locale_files:
         with codecs.open(locale_file, 'r', encoding='utf-8') as f:
             trans = json.load(f)


### PR DESCRIPTION
Just bringing this handy script up to date to:

1) Depend on python 3 like everything else
2) Update location of where the locale json files are (./share/locale)
3) Remove check of .html files for strings, which isn't applicable anymore, and seemed to halt the script from completing
4) Add an -l argument to filter on a specific language code e.g '-l fr' to see just disused/lacked translations in the French json