### PR TITLE
Don't save settings object from onionshare/__init__.py if running on Windows

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -129,10 +129,11 @@ def main(cwd=None):
             app.shutdown_timer.start()
 
         # Save the web slug if we are using a persistent private key
-        if settings.get('save_private_key'):
-            if not settings.get('slug'):
-                settings.set('slug', web.slug)
-                settings.save()
+        if common.get_platform() != 'Windows':
+            if settings.get('save_private_key'):
+                if not settings.get('slug'):
+                    settings.set('slug', web.slug)
+                    settings.save()
 
         if(stealth):
             print(strings._("give_this_url_stealth"))


### PR DESCRIPTION
So I wonder something

1) Do you reproduce #543 (persistent .onion is not persistent on Windows, but the slug is, so long as the app stays open)

2) Does this patch fix it for you too, on Windows, as it seems to for me

I am working on the theory that it's something to do with the lack of the command-line mode in Windows, and that when it tried to save the web.slug back to settings via the Settings object, that object's 'config' parameter is False, so it used the 'default' settings, and saves ```'use_private_key': false``` back to the settings file, overwriting what was previously ```'save_private_key': true``` in the json after you save the SettingsDialog but before you start a share.

And that somehow this is not an issue on Linux (haven't tested MacOS), presumably because somehow the 'config' object when passed to OnionShare is not null, or avoids it in some way I don't fully understand.

With this patch, I get the expected big private key and slug saved to the json in Windows, but without, it it is as if it 'resets' back to false/empty settings as soon as the share starts.

Sorry about these surprise bugs in my features on the eve of a release :( ugh