### PR TITLE
load the Settings in onionshare/__init__.py later,

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -79,7 +79,6 @@ def main(cwd=None):
 
 
     settings = Settings(config)
-    settings.load()
 
     # Start the Onion object
     onion = Onion()
@@ -129,6 +128,7 @@ def main(cwd=None):
             app.shutdown_timer.start()
 
         # Save the web slug if we are using a persistent private key
+        settings.load()
         if settings.get('save_private_key'):
             if not settings.get('slug'):
                 settings.set('slug', web.slug)


### PR DESCRIPTION
...so that when saving slug, the private_key/hidservauth string have already been saved by the Onion object

*This* was the cause of the slug being saved to Settings json, but not the private key - something I observed on Windows, and then later when using the 'CLI' mode on Linux, in a scenario when save_private_key = True, but there hasn't yet been a share (so no existing private key to rely on, but it should save it back on the next share)