### PR TITLE
load Settings in onionshare/__init__.py before we initiate the web thread, since it needs to send the saved slug to the web server

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -115,6 +115,7 @@ def main(cwd=None):
         print('')
 
     # Start OnionShare http service in new thread
+    settings.load()
     t = threading.Thread(target=web.start, args=(app.port, app.stay_open, settings.get('slug')))
     t.daemon = True
     t.start()
@@ -128,7 +129,6 @@ def main(cwd=None):
             app.shutdown_timer.start()
 
         # Save the web slug if we are using a persistent private key
-        settings.load()
         if settings.get('save_private_key'):
             if not settings.get('slug'):
                 settings.set('slug', web.slug)


### PR DESCRIPTION
Fixes #552 

Back in #547 the private key was not being loaded from settings yet when saving the Slug - we needed to load Settings after the Onion object had saved the private key in order to know about it.

The fix there kind of introduced the *opposite* effect by accident: we now load the Settings too *late* - we need to load it before we initiate the webserver thread, because we need to send the web server the saved slug so that it doesn't think it has to generate a new one.

Without this fix, the CLI mode reuses the private key but generates a new slug instead of using the saved one from settings.

The GUI already loaded Settings at the right time before its invoking of the web server thread so was not affected.