### PR TITLE
Eject dmg

### DIFF
--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -88,8 +88,8 @@ def main():
     shutil.copyfile(os.path.join(dmg_tor_path, 'MacOS', 'Tor', 'PluggableTransports', 'obfs4proxy'), os.path.join(dist_path, 'Resources', 'Tor', 'obfs4proxy'))
     os.chmod(os.path.join(dist_path, 'Resources', 'Tor', 'obfs4proxy'), 0o755)
 
-    # Unmount dmg
-    subprocess.call(['diskutil', 'unmount', '/Volumes/Tor Browser'])
+    # Eject dmg
+    subprocess.call(['diskutil', 'eject', '/Volumes/Tor Browser'])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When installing The Dmg should be ejected not on unmounted. If you just on unmount the Dmg will still show up inside of Disk Utility.