### PR TITLE
Support deleting an item from the file widget with the delete key on a keyboard

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -127,6 +127,24 @@ class FileList(QtWidgets.QListWidget):
             event.ignore()
         self.files_dropped.emit()
 
+    def keyPressEvent(self, event):
+        """
+        Allows deleting of items in the file list via the Delete key.
+        """
+        if event.key() == QtCore.Qt.Key_Delete:
+            self.delete_file()
+
+    def delete_file(self):
+        """
+        Delete a file or directory from the widget.
+        """
+        selected = self.selectedItems()
+        for item in selected:
+            itemrow = self.row(item)
+            self.filenames.pop(itemrow)
+            self.takeItem(itemrow)
+            self.files_updated.emit()
+
     def add_file(self, filename):
         """
         Add a file or directory to this widget.


### PR DESCRIPTION
This just speeds up the UX a bit, allowing the Delete key on a keyboard to remove items from the list rather than click the Delete qPushbutton.