### PR TITLE
#535 do the forced update check via a (non-blocking) QThread

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -557,31 +557,34 @@ class SettingsDialog(QtWidgets.QDialog):
         self._disable_buttons()
         self.qtapp.processEvents()
 
+        def update_timestamp():
+            # Update the last checked label
+            settings = Settings(self.config)
+            settings.load()
+            autoupdate_timestamp = settings.get('autoupdate_timestamp')
+            self._update_autoupdate_timestamp(autoupdate_timestamp)
+
         # Check for updates
         def update_available(update_url, installed_version, latest_version):
             Alert(strings._("update_available", True).format(update_url, installed_version, latest_version))
+            forced_update_thread.quit()
+            # Enable buttons
+            self._enable_buttons()
+            # Update timestamp
+            update_timestamp()
+
         def update_not_available():
             Alert(strings._('update_not_available', True))
+            forced_update_thread.quit()
+            # Enable buttons
+            self._enable_buttons()
+            # Update timestamp
+            update_timestamp()
 
-        u = UpdateChecker(self.onion)
-        u.update_available.connect(update_available)
-        u.update_not_available.connect(update_not_available)
-
-        try:
-            u.check(force=True)
-        except UpdateCheckerCheckError:
-            Alert(strings._('update_error_check_error', True), QtWidgets.QMessageBox.Warning)
-        except UpdateCheckerInvalidLatestVersion as e:
-            Alert(strings._('update_error_invalid_latest_version', True).format(e.latest_version), QtWidgets.QMessageBox.Warning)
-
-        # Enable buttons
-        self._enable_buttons()
-
-        # Update the last checked label
-        settings = Settings(self.config)
-        settings.load()
-        autoupdate_timestamp = settings.get('autoupdate_timestamp')
-        self._update_autoupdate_timestamp(autoupdate_timestamp)
+        forced_update_thread = UpdateThread(self.onion, self.config, force=True)
+        forced_update_thread.update_available.connect(update_available)
+        forced_update_thread.update_not_available.connect(update_not_available)
+        forced_update_thread.start()
 
     def save_clicked(self):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -564,26 +564,35 @@ class SettingsDialog(QtWidgets.QDialog):
             autoupdate_timestamp = settings.get('autoupdate_timestamp')
             self._update_autoupdate_timestamp(autoupdate_timestamp)
 
-        # Check for updates
-        def update_available(update_url, installed_version, latest_version):
-            Alert(strings._("update_available", True).format(update_url, installed_version, latest_version))
+        def close_forced_update_thread():
             forced_update_thread.quit()
             # Enable buttons
             self._enable_buttons()
             # Update timestamp
             update_timestamp()
 
+        # Check for updates
+        def update_available(update_url, installed_version, latest_version):
+            Alert(strings._("update_available", True).format(update_url, installed_version, latest_version))
+            close_forced_update_thread()
+
         def update_not_available():
             Alert(strings._('update_not_available', True))
-            forced_update_thread.quit()
-            # Enable buttons
-            self._enable_buttons()
-            # Update timestamp
-            update_timestamp()
+            close_forced_update_thread()
+
+        def update_error():
+            Alert(strings._('update_error_check_error', True), QtWidgets.QMessageBox.Warning)
+            close_forced_update_thread()
+
+        def update_invalid_version():
+            Alert(strings._('update_error_invalid_latest_version', True).format(e.latest_version), QtWidgets.QMessageBox.Warning)
+            close_forced_update_thread()
 
         forced_update_thread = UpdateThread(self.onion, self.config, force=True)
         forced_update_thread.update_available.connect(update_available)
         forced_update_thread.update_not_available.connect(update_not_available)
+        forced_update_thread.update_error.connect(update_error)
+        forced_update_thread.update_invalid_version.connect(update_invalid_version)
         forced_update_thread.start()
 
     def save_clicked(self):

--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -149,11 +149,12 @@ class UpdateThread(QtCore.QThread):
     update_available = QtCore.pyqtSignal(str, str, str)
     update_not_available = QtCore.pyqtSignal()
 
-    def __init__(self, onion, config=False):
+    def __init__(self, onion, config=False, force=False):
         super(UpdateThread, self).__init__()
         common.log('UpdateThread', '__init__')
         self.onion = onion
         self.config = config
+        self.force = force
 
     def run(self):
         common.log('UpdateThread', 'run')
@@ -163,7 +164,7 @@ class UpdateThread(QtCore.QThread):
         u.update_not_available.connect(self._update_not_available)
 
         try:
-            u.check(config=self.config)
+            u.check(config=self.config,force=self.force)
         except Exception as e:
             # If update check fails, silently ignore
             common.log('UpdateThread', 'run', '{}'.format(e))

--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -51,6 +51,8 @@ class UpdateChecker(QtCore.QObject):
     """
     update_available = QtCore.pyqtSignal(str, str, str)
     update_not_available = QtCore.pyqtSignal()
+    update_error = QtCore.pyqtSignal()
+    update_invalid_version = QtCore.pyqtSignal()
 
     def __init__(self, onion, config=False):
         super(UpdateChecker, self).__init__()
@@ -120,12 +122,14 @@ class UpdateChecker(QtCore.QObject):
 
             except Exception as e:
                 common.log('UpdateChecker', 'check', '{}'.format(e))
+                self.update_error.emit()
                 raise UpdateCheckerCheckError
 
             # Validate that latest_version looks like a version string
             # This regex is: 1-3 dot-separated numeric components
             version_re = r"^(\d+\.)?(\d+\.)?(\d+)$"
             if not re.match(version_re, latest_version):
+                self.update_invalid_version.emit()
                 raise UpdateCheckerInvalidLatestVersion(latest_version)
 
             # Update the last checked timestamp (dropping the seconds and milliseconds)
@@ -148,6 +152,8 @@ class UpdateChecker(QtCore.QObject):
 class UpdateThread(QtCore.QThread):
     update_available = QtCore.pyqtSignal(str, str, str)
     update_not_available = QtCore.pyqtSignal()
+    update_error = QtCore.pyqtSignal()
+    update_invalid_version = QtCore.pyqtSignal()
 
     def __init__(self, onion, config=False, force=False):
         super(UpdateThread, self).__init__()
@@ -162,6 +168,8 @@ class UpdateThread(QtCore.QThread):
         u = UpdateChecker(self.onion, self.config)
         u.update_available.connect(self._update_available)
         u.update_not_available.connect(self._update_not_available)
+        u.update_error.connect(self._update_error)
+        u.update_invalid_version.connect(self._update_invalid_version)
 
         try:
             u.check(config=self.config,force=self.force)
@@ -179,3 +187,13 @@ class UpdateThread(QtCore.QThread):
         common.log('UpdateThread', '_update_not_available')
         self.active = False
         self.update_not_available.emit()
+
+    def _update_error(self):
+        common.log('UpdateThread', '_update_error')
+        self.active = False
+        self.update_error.emit()
+
+    def _update_invalid_version(self):
+        common.log('UpdateThread', '_update_invalid_version')
+        self.active = False
+        self.update_invalid_version.emit()


### PR DESCRIPTION
I'm not sure if this is the best method, but this PR changes the 'Forced' update checker to be via a new instance of the UpdateThread QThread, so it doesn't block the app by calling UpdateCheck directly.

I couldn't find a way to do it any other way (e.g messing with socket timeouts), ultimately I think threading or queuing is the best method, and we already have the thread logic, so we may as well reuse it?

The thread only lingers until the check is complete, then it closes the thread.

Introduces a new parameter to UpdateThread 'force', so that it can carry through to the underlying UpdateCheck from the thread.

For me this fixes #535 on both macOS and Windows.