### PR TITLE
Bump tor to 0.2.3.9

### DIFF
--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, zipfile, io, shutil, subprocess
 import urllib.request
 
 def main():
-    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.11/TorBrowser-7.0.11-osx64_en-US.dmg'
-    dmg_filename = 'TorBrowser-7.0.11-osx64_en-US.dmg'
-    expected_dmg_sha256 = '5143e4a2141a69f66869be13eef4bcaac4e6c27c78383fc8a4c38b334759f3a2'
+    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.5/TorBrowser-7.5-osx64_en-US.dmg'
+    dmg_filename = 'TorBrowser-7.5-osx64_en-US.dmg'
+    expected_dmg_sha256 = '43a8dc0afd0a77e42766311eb54ad9fc8714f67fcd2d3582a3bcb98b22c2e629'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))

--- a/install/get-tor-windows.py
+++ b/install/get-tor-windows.py
@@ -28,9 +28,9 @@ import inspect, os, sys, hashlib, shutil, subprocess
 import urllib.request
 
 def main():
-    exe_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.0.11/torbrowser-install-7.0.11_en-US.exe'
-    exe_filename = 'torbrowser-install-7.0.11_en-US.exe'
-    expected_exe_sha256 = 'a033eb9b9ed2ad389169b36a90946a8af8f05bd0c7bbd3e37678041331096624'
+    exe_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/7.5/torbrowser-install-7.5_en-US.exe'
+    exe_filename = 'torbrowser-install-7.5_en-US.exe'
+    expected_exe_sha256 = '81ccb9456118cf8fa755a3eafb5c514665fc69599cdd41e9eb36baa335ebe233'
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))
     working_path = os.path.join(os.path.join(root_path, 'build'), 'tor')


### PR DESCRIPTION
TorBrowser 7.5 was officially released and Onionshare should bump Tor to the latest stable https://blog.torproject.org/tor-browser-75-released