### PR TITLE
#523 prioritise connecting to the v3 onionshare site when checking for updates

### DIFF
--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt5 import QtCore
 import datetime, time, socket, re, platform
+from distutils.version import LooseVersion as Version
 
 from onionshare import socks
 from onionshare.settings import Settings
@@ -96,7 +97,10 @@ class UpdateChecker(QtCore.QObject):
                 if force:
                     path += '?force=1'
 
-                onion_domain = 'elx57ue5uyfplgva.onion'
+                if Version(self.onion.tor_version) >= Version('0.3.2.9'):
+                    onion_domain = 'lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion'
+                else:
+                    onion_domain = 'elx57ue5uyfplgva.onion'
 
                 common.log('UpdateChecker', 'check', 'loading http://{}{}'.format(onion_domain, path))
 


### PR DESCRIPTION
…if Tor version is >= 0.3.2.9

Fixes the update-checking component of #523

```
[Jan 24 2018 11:46:31] UpdateChecker.check: checking for updates
[Jan 24 2018 11:46:31] UpdateChecker.check: loading http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/latest-version.txt?force=1
[Jan 24 2018 11:46:31] Onion.get_tor_socks_port
[Jan 24 2018 11:46:45] UpdateChecker.check: latest OnionShare version: 1.2
```

Probably best worth testing with the patch from #568, or merge that PR first, or use 'Tor Browser' connection mode with v7.5, rather than bundled.