### PR TITLE
[WIP] Support v3 onions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "nightly"
 # command to install dependencies
 install:
-  - pip install Flask==0.12 stem==1.5.4 pytest-cov coveralls
+  - pip install Flask==0.12 stem==1.5.4 pytest-cov pycrypto pynacl cryptography coveralls
 # command to run tests
 script: pytest --cov=onionshare test/
 after_success:

--- a/BUILD.md
+++ b/BUILD.md
@@ -11,9 +11,11 @@ cd onionshare
 
 Install the needed dependencies:
 
-For Debian-like distros: `apt install -y build-essential fakeroot python3-all python3-stdeb dh-python  python3-flask python3-stem python3-pyqt5 python-nautilus python3-pytest tor obfs4proxy`
+For Debian-like distros: `apt install -y build-essential fakeroot python3-all python3-stdeb dh-python  python3-flask python3-stem python3-pyqt5 python-nautilus python3-pytest python3-cryptography python3-crypto python3-nacl tor obfs4proxy`
 
-For Fedora-like distros: `dnf install -y rpm-build python3-flask python3-stem python3-qt5 python3-pytest nautilus-python tor obfs4`
+For Fedora-like distros: `dnf install -y rpm-build python3-flask python3-stem python3-qt5 python3-pytest python3-pynacl python3-cryptography python3-crypto nautilus-python tor obfs4`
+
+If you find your distro doesn't have some of the Python packages, you can pip3 install them.
 
 After that you can try both the CLI and the GUI version of OnionShare:
 

--- a/install/requirements-windows.txt
+++ b/install/requirements-windows.txt
@@ -1,10 +1,12 @@
 click==6.7
+cryptography==2.1.4
 Flask==0.12.2
 future==0.16.0
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
 pefile==2017.11.5
+pynacl==1.2.1
 PyInstaller==3.3.1
 PyQt5==5.9.2
 PySocks==1.6.7

--- a/install/requirements-windows.txt
+++ b/install/requirements-windows.txt
@@ -8,6 +8,7 @@ pefile==2017.11.5
 PyInstaller==3.3.1
 PyQt5==5.9.2
 PySocks==1.6.7
+pycrypto==2.6.1
 sip==4.19.6
 stem==1.6.0
 Werkzeug==0.14.1

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -6,6 +6,7 @@ MarkupSafe==1.0
 PyInstaller==3.3.1
 PyQt5==5.9.2
 PySocks==1.6.7
+pycrypto==2.6.1
 sip==4.19.6
 stem==1.6.0
 Werkzeug==0.14.1

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -1,9 +1,11 @@
 click==6.7
+cryptography==2.1.4
 Flask==0.12.2
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
 PyInstaller==3.3.1
+pynacl==1.2.1
 PyQt5==5.9.2
 PySocks==1.6.7
 pycrypto==2.6.1

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -430,14 +430,15 @@ class Onion(object):
             basic_auth = None
 
         if self.settings.get('private_key'):
-            # Decode the key
-            key_decoded = b64decode(self.settings.get('private_key'))
-            # Import the key
-            key = RSA.importKey(key_decoded)
-            # Is this a v2 Onion key? (1024 bits)
-            if key.n.bit_length() == 1024:
-                key_type = "RSA1024"
-            else:
+            try:
+                # Decode the key
+                key_decoded = b64decode(self.settings.get('private_key'))
+                # Import the key
+                key = RSA.importKey(key_decoded)
+                # Is this a v2 Onion key? (1024 bits)
+                if key.n.bit_length() == 1024:
+                    key_type = "RSA1024"
+            except:
                 # Assume it was a v3 key
                 key_type = "ED25519-V3"
             key_content = self.settings.get('private_key')
@@ -445,7 +446,7 @@ class Onion(object):
         else:
             key_type = "NEW"
             # Work out if we can support v3 onion services
-            if Version(self.onion.tor_version) >= Version('0.3.3'):
+            if Version(self.tor_version) >= Version('0.3.3'):
                 key_content = "ED25519-V3"
             else:
                 # fall back to v2 onion services
@@ -459,10 +460,10 @@ class Onion(object):
 
         try:
             if basic_auth != None:
-                res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication=True, basic_auth=basic_auth, key_type = key_type, key_content=key_content)
+                res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication=True, basic_auth=basic_auth, key_type=key_type, key_content=key_content)
             else:
                 # if the stem interface is older than 1.5.0, basic_auth isn't a valid keyword arg
-                res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication=True, key_type = key_type, key_content=key_content)
+                res = self.c.create_ephemeral_hidden_service({ 80: port }, await_publication=True, key_type=key_type, key_content=key_content)
 
         except ProtocolError:
             raise TorErrorProtocolError(strings._('error_tor_protocol_error'))

--- a/onionshare/onionkey.py
+++ b/onionshare/onionkey.py
@@ -24,6 +24,8 @@ import os
 
 import nacl.signing
 
+from Crypto.PublicKey import RSA
+
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -88,3 +90,18 @@ def generate_v2_secret_key():
     serialized_key = ''.join(pem_format.decode().split('\n')[1:-2])
 
     return (serialized_key, onion_url)
+
+def is_v2_key(key):
+    """
+    Helper function for determining if a key is RSA1024 (v2) or not.
+    """
+    try:
+        # Import the key
+        key = RSA.importKey(base64.b64decode(key))
+        # Is this a v2 Onion key? (1024 bits) If so, we should keep using it.
+        if key.n.bit_length() == 1024:
+            return True
+        else:
+            return False
+    except:
+        return False

--- a/onionshare/onionkey.py
+++ b/onionshare/onionkey.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+OnionShare | https://onionshare.org/
+
+Copyright (C) 2017 Micah Lee <micah@micahflee.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import base64
+import hashlib
+import os
+
+import nacl.signing
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+b = 256
+
+def bit(h, i):
+    return (h[i // 8] >> (i % 8)) & 1
+
+
+def encodeint(y):
+    bits = [(y >> i) & 1 for i in range(b)]
+    return b''.join([bytes([(sum([bits[i * 8 + j] << j for j in range(8)]))]) for i in range(b // 8)])
+
+
+def H(m):
+    return hashlib.sha512(m).digest()
+
+
+def expandSK(sk):
+    h = H(sk)
+    a = 2 ** (b - 2) + sum(2 ** i * bit(h, i) for i in range(3, b - 2))
+    k = b''.join([bytes([h[i]]) for i in range(b // 8, b // 4)])
+    assert len(k) == 32
+    return encodeint(a) + k
+
+
+def onion_url_from_secret_key(secret_key):
+    secret_key = nacl.signing.SigningKey(seed=secret_key)
+    pubkey = bytes(secret_key.verify_key)
+    version = b'\x03'
+    checksum = hashlib.sha3_256(b".onion checksum" + pubkey + version).digest()[:2]
+    onion_address = "http://{}.onion".format(base64.b32encode(pubkey + checksum + version).decode().lower())
+    return onion_address
+
+
+def generate_v3_secret_key():
+    secretKey = os.urandom(32)
+    expandedSecretKey = expandSK(secretKey)
+    private_key = base64.b64encode(expandedSecretKey).decode()
+    return (private_key, onion_url_from_secret_key(secretKey))
+
+def generate_v2_secret_key():
+    # Generate Onion Service key pair
+    private_key = rsa.generate_private_key(public_exponent=65537,
+                                           key_size=1024,
+                                           backend=default_backend())
+    hs_public_key = private_key.public_key()
+
+    # Pre-generate Onion URL
+    der_format = hs_public_key.public_bytes(encoding=serialization.Encoding.DER,
+                                            format=serialization.PublicFormat.PKCS1)
+
+    onion_url = base64.b32encode(hashlib.sha1(der_format).digest()[:-10]).lower().decode()
+
+
+    # Generate Stem-compatible key content
+    pem_format = private_key.private_bytes(encoding=serialization.Encoding.PEM,
+                                           format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                           encryption_algorithm=serialization.NoEncryption())
+    serialized_key = ''.join(pem_format.decode().split('\n')[1:-2])
+
+    return (serialized_key, onion_url)

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -19,8 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from PyQt5 import QtCore, QtWidgets, QtGui
 import sys, platform, datetime, re
+from distutils.version import LooseVersion as Version
 
-from onionshare import strings, common
+from onionshare import strings, common, onionkey
 from onionshare.settings import Settings
 from onionshare.onion import *
 
@@ -64,12 +65,15 @@ class SettingsDialog(QtWidgets.QDialog):
         self.save_private_key_checkbox = QtWidgets.QCheckBox()
         self.save_private_key_checkbox.setCheckState(QtCore.Qt.Unchecked)
         self.save_private_key_checkbox.setText(strings._("gui_save_private_key_checkbox", True))
+        self.private_key_is_v2_label = QtWidgets.QLabel(strings._("gui_private_key_is_v2", True))
+        self.private_key_is_v2_label.hide()
 
         # Sharing options layout
         sharing_group_layout = QtWidgets.QVBoxLayout()
         sharing_group_layout.addWidget(self.close_after_first_download_checkbox)
         sharing_group_layout.addWidget(self.systray_notifications_checkbox)
         sharing_group_layout.addWidget(self.save_private_key_checkbox)
+        sharing_group_layout.addWidget(self.private_key_is_v2_label)
         sharing_group = QtWidgets.QGroupBox(strings._("gui_settings_sharing_label", True))
         sharing_group.setLayout(sharing_group_layout)
 
@@ -352,6 +356,9 @@ class SettingsDialog(QtWidgets.QDialog):
         save_private_key = self.old_settings.get('save_private_key')
         if save_private_key:
             self.save_private_key_checkbox.setCheckState(QtCore.Qt.Checked)
+            if self.onion.is_authenticated() and self.old_settings.get('private_key'):
+                if onionkey.is_v2_key(self.old_settings.get('private_key')) and Version(self.onion.tor_version) >= Version('0.3.3'):
+                    self.private_key_is_v2_label.show()
         else:
             self.save_private_key_checkbox.setCheckState(QtCore.Qt.Unchecked)
 

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -132,5 +132,6 @@
     "gui_server_timeout_expired": "The chosen timeout has already expired.\nPlease update the timeout and then you may start sharing.",
     "share_via_onionshare": "Share via OnionShare",
     "gui_save_private_key_checkbox": "Use a persistent URL\n(unchecking will delete any saved URL)",
+    "gui_private_key_is_v2": "Your Tor version supports v3 onion service, but your persistent URL is v2.\nUncheck this setting to remove your v2 URL and start using v3.",
     "persistent_url_in_use": "This share is using a persistent URL"
 }


### PR DESCRIPTION
As per #461 

This is not quite ready but I thought I'd put it up in advance.

It features the pre-generation of private keys by @maqp which seems to solve some weird issues I had with persistent v3 private keys. That work will also be useful for the 'startup timer' by being able to show the URL 'early' without having to share a persistent share just to obtain the persistent URL for later (not yet implemented).

A few things I still need to do here:

~~~1) Make it clear to a user of v2 persistent URLs that they need to remove their persistent URL if they want to upgrade to v3 (if their Tor supports it) - we don't want to surpruse them by destroying their existing v2 private key in favour of v3 (but we favour v3 otherwise)~~~

2) See if I can remove the dependency on pycrypto - I am using that module to determine if the existing v2 persistent private key is 1024 bits or not. I'm sure the cryptography module that we introduced for pre-generating keys, can do this, but I haven't looked yet

~~~3) Test the stealth mode with v2 since we pre-generate the auth cookie too now (as per 1), because it will be useful for 'showing early' pre-share ) but it should be fine~~~

4) Probably some cleanup/doublechecking module versions/package names in the install/requirements*.txt and BUILD.md

5) Testing on macOS or Windows (only Linux so far, with a custom compiled tor 0.3.3 alpha)
