### PR TITLE
Add myself as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @micahflee


### PR DESCRIPTION
Because there is quite a bit of active development within the OnionShare project, I'm starting to lock down the github repository, while at the same time giving contributors more access.

I've changed the default branch to `develop`, so PRs will get merged there by default. I also made the `master` branch protected, and made it so PRs can only get merged into it if they've been reviewed by a "code owner". This PR makes me the code owner for the full project.

So in short, collaborators will be able to review each other's pull requests, and after they've been reviewed merge them into `develop`. But when we're ready to make a release, we can only merge `develop` into `master` if I've personally reviewed it.