### PR TITLE
Second attempt at patches for an OpenBSD port

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -23,6 +23,7 @@ import inspect
 import os
 import platform
 import random
+import re
 import socket
 import sys
 import tempfile
@@ -56,8 +57,10 @@ def get_platform():
     """
     Returns the platform OnionShare is running on.
     """
-    return platform.system()
-
+    plat = platform.system() 
+    if re.match('^.*BSD$', plat):
+        plat = 'BSD'
+    return plat
 
 def get_resource_path(filename):
     """
@@ -73,7 +76,7 @@ def get_resource_path(filename):
             # While running tests during stdeb bdist_deb, look 3 directories up for the share folder
             prefix = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(prefix)))), 'share')
 
-    elif p == 'Linux':
+    elif p == 'BSD' or p == 'Linux':
         # Assume OnionShare is installed systemwide in Linux, since we're not running in dev mode
         prefix = os.path.join(sys.prefix, 'share/onionshare')
 
@@ -107,7 +110,7 @@ def get_tor_paths():
         tor_geo_ip_file_path   = os.path.join(base_path, 'Resources', 'Tor', 'geoip')
         tor_geo_ipv6_file_path = os.path.join(base_path, 'Resources', 'Tor', 'geoip6')
         obfs4proxy_file_path   = os.path.join(base_path, 'Resources', 'Tor', 'obfs4proxy')
-    elif p == 'OpenBSD' or p == 'FreeBSD':
+    elif p == 'BSD':
         tor_path = '/usr/local/bin/tor'
         tor_geo_ip_file_path = '/usr/local/share/tor/geoip'
         tor_geo_ipv6_file_path = '/usr/local/share/tor/geoip6'

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -316,7 +316,8 @@ class Onion(object):
             # guessing the socket file name next
             if not found_tor:
                 try:
-                    if self.system == 'Linux':
+                    plat = common.get_platform()
+                    if plat == 'Linux' or plat == 'BSD':
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())
                     elif self.system == 'Darwin':
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -131,7 +131,7 @@ class Onion(object):
         self.stealth = False
         self.service_id = None
 
-        self.system = platform.system()
+        self.system = common.get_platform()
 
         # Is bundled tor supported?
         if (self.system == 'Windows' or self.system == 'Darwin') and getattr(sys, 'onionshare_dev_mode', False):
@@ -183,7 +183,7 @@ class Onion(object):
                     raise OSError(strings._('no_available_port'))
                 self.tor_torrc = os.path.join(self.tor_data_directory.name, 'torrc')
             else:
-                # Linux and Mac can use unix sockets
+                # Linux, Mac and BSD can use unix sockets
                 with open(common.get_resource_path('torrc_template')) as f:
                     torrc_template = f.read()
                 self.tor_control_port = None
@@ -316,8 +316,7 @@ class Onion(object):
             # guessing the socket file name next
             if not found_tor:
                 try:
-                    plat = common.get_platform()
-                    if plat == 'Linux' or plat == 'BSD':
+                    if self.system == 'Linux' or self.system == 'BSD':
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())
                     elif self.system == 'Darwin':
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())

--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -298,7 +298,8 @@ def download(slug_candidate):
                     percent = (1.0 * downloaded_bytes / zip_filesize) * 100
 
                     # only output to stdout if running onionshare in CLI mode, or if using Linux (#203, #304)
-                    if not gui_mode or common.get_platform() == 'Linux':
+                    plat = common.get_platform()
+                    if not gui_mode or plat == 'Linux' or plat == 'BSD':
                         sys.stdout.write(
                             "\r{0:s}, {1:.2f}%          ".format(common.human_readable_filesize(downloaded_bytes), percent))
                         sys.stdout.flush()

--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -35,8 +35,8 @@ class Application(QtWidgets.QApplication):
     and the quick keyboard shortcut.
     """
     def __init__(self):
-        system = platform.system()
-        if system == 'Linux':
+        system = common.get_platform()
+        if system == 'Linux' or system == 'BSD':
             self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
         QtWidgets.QApplication.__init__(self, sys.argv)
         self.installEventFilter(self)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,17 @@ author_email = 'micah@micahflee.com'
 url = 'https://github.com/micahflee/onionshare'
 license = 'GPL v3'
 keywords = 'onion, share, onionshare, tor, anonymous, web server'
+data_files=[
+        (os.path.join(sys.prefix, 'share/applications'), ['install/onionshare.desktop']),
+        (os.path.join(sys.prefix, 'share/appdata'), ['install/onionshare.appdata.xml']),
+        (os.path.join(sys.prefix, 'share/pixmaps'), ['install/onionshare80.xpm']),
+        (os.path.join(sys.prefix, 'share/onionshare'), file_list('share')),
+        (os.path.join(sys.prefix, 'share/onionshare/images'), file_list('share/images')),
+        (os.path.join(sys.prefix, 'share/onionshare/locale'), file_list('share/locale')),
+        (os.path.join(sys.prefix, 'share/onionshare/html'), file_list('share/html')),
+    ]
+if platform.system() != 'OpenBSD':
+    data_files.append(('/usr/share/nautilus-python/extensions/', ['install/scripts/onionshare-nautilus.py']))
 
 setup(
     name='onionshare', version=version,
@@ -54,14 +65,5 @@ setup(
     packages=['onionshare', 'onionshare_gui'],
     include_package_data=True,
     scripts=['install/scripts/onionshare', 'install/scripts/onionshare-gui'],
-    data_files=[
-        (os.path.join(sys.prefix, 'share/applications'), ['install/onionshare.desktop']),
-        (os.path.join(sys.prefix, 'share/appdata'), ['install/onionshare.appdata.xml']),
-        (os.path.join(sys.prefix, 'share/pixmaps'), ['install/onionshare80.xpm']),
-        (os.path.join(sys.prefix, 'share/onionshare'), file_list('share')),
-        (os.path.join(sys.prefix, 'share/onionshare/images'), file_list('share/images')),
-        (os.path.join(sys.prefix, 'share/onionshare/locale'), file_list('share/locale')),
-        (os.path.join(sys.prefix, 'share/onionshare/html'), file_list('share/html')),
-        ('/usr/share/nautilus-python/extensions/', ['install/scripts/onionshare-nautilus.py'])
-    ]
+    data_files=data_files
 )


### PR DESCRIPTION
… this time based off of 1.2 and after feedback from the upstream and other contributors at
https://github.com/micahflee/onionshare/pull/489

Instead of the "unixy" stuff I just add 'BSD' as a possible return value for
get_platform() and use it in several places.  The idea of collapsing everything
down to Darwin/Windows/Unixy doesn't quite work out because we need to
distinguish between Linux and BSD in one place, so I thought this way of doing
it made it read more naturally.  I also tried to deal with an issue in setup.py
in a way that might be acceptable to you.

Cheers, -A