### PR TITLE
Fix URL QLabel squish issue

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -77,6 +77,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.server_status.server_stopped.connect(self.file_selection.server_stopped)
         self.server_status.server_stopped.connect(self.stop_server)
         self.server_status.server_stopped.connect(self.update_server_status_indicator)
+        self.server_status.server_stopped.connect(self.update_primary_action)
         self.start_server_finished.connect(self.clear_message)
         self.start_server_finished.connect(self.server_status.start_server_finished)
         self.start_server_finished.connect(self.update_server_status_indicator)

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -84,10 +84,14 @@ class ServerStatus(QtWidgets.QWidget):
         # URL layout
         url_font = QtGui.QFont()
         self.url_description = QtWidgets.QLabel(strings._('gui_url_description', True))
+        self.url_description.setWordWrap(True)
+        self.url_description.setMinimumHeight(50)
         self.url_label = QtWidgets.QLabel()
         self.url_label.setStyleSheet('QLabel { color: #666666; font-size: 12px; }')
         self.url = QtWidgets.QLabel()
         self.url.setFont(url_font)
+        self.url.setWordWrap(True)
+        self.url.setMinimumHeight(60)
         self.url.setStyleSheet('QLabel { background-color: #ffffff; color: #000000; padding: 10px; border: 1px solid #666666; }')
 
         url_buttons_style = 'QPushButton { color: #3f7fcf; }'


### PR DESCRIPTION
Fixes that annoying squishing of QLabels when they get shown.. setting a minimum height forces the parents to adjust to suit.

Also adds a connect() to update_primary_action when server is stopped. This ensures the overall GUI resizes back down to the original size once those widgets are hidden on stop.