### PR TITLE
Hide the FileList delete buttons when a share is running, so items can't be deleted mid-share

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -205,16 +205,16 @@ class FileList(QtWidgets.QListWidget):
                 self.takeItem(itemrow)
                 self.files_updated.emit()
 
-            item_button = QtWidgets.QPushButton()
-            item_button.setDefault(False)
-            item_button.setFlat(True)
-            item_button.setIcon( QtGui.QIcon(common.get_resource_path('images/file_delete.png')) )
-            item_button.clicked.connect(delete_item)
+            item.item_button = QtWidgets.QPushButton()
+            item.item_button.setDefault(False)
+            item.item_button.setFlat(True)
+            item.item_button.setIcon( QtGui.QIcon(common.get_resource_path('images/file_delete.png')) )
+            item.item_button.clicked.connect(delete_item)
 
             # Create an item widget to display on the item
             item_widget_layout = QtWidgets.QHBoxLayout()
             item_widget_layout.addStretch()
-            item_widget_layout.addWidget(item_button)
+            item_widget_layout.addWidget(item.item_button)
             item_widget = QtWidgets.QWidget()
             item_widget.setLayout(item_widget_layout)
 

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -178,6 +178,12 @@ class ServerStatus(QtWidgets.QWidget):
             self.copy_url_button.hide()
             self.copy_hidservauth_button.hide()
 
+        # Set the File List widget to readonly while running, so items can't be deleted mid-share
+        if self.status == self.STATUS_STARTED or self.status == self.STATUS_WORKING:
+            self.file_selection.file_list.setEnabled(False)
+        else:
+            self.file_selection.file_list.setEnabled(True)
+
         # Button
         button_stopped_style = 'QPushButton { background-color: #5fa416; color: #ffffff; padding: 10px; border: 0; border-radius: 5px; }'
         button_working_style = 'QPushButton { background-color: #4c8211; color: #ffffff; padding: 10px; border: 0; border-radius: 5px; font-style: italic; }'

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -178,7 +178,7 @@ class ServerStatus(QtWidgets.QWidget):
             self.copy_url_button.hide()
             self.copy_hidservauth_button.hide()
 
-        # Set the File List widget to readonly while running, so items can't be deleted mid-share
+        # Hide the FileList delete buttons when a share is running
         if self.status == self.STATUS_STARTED or self.status == self.STATUS_WORKING:
             for index in range(self.file_selection.file_list.count()):
                 self.file_selection.file_list.item(index).item_button.hide()

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -180,9 +180,11 @@ class ServerStatus(QtWidgets.QWidget):
 
         # Set the File List widget to readonly while running, so items can't be deleted mid-share
         if self.status == self.STATUS_STARTED or self.status == self.STATUS_WORKING:
-            self.file_selection.file_list.setEnabled(False)
+            for index in range(self.file_selection.file_list.count()):
+                self.file_selection.file_list.item(index).item_button.hide()
         else:
-            self.file_selection.file_list.setEnabled(True)
+            for index in range(self.file_selection.file_list.count()):
+                self.file_selection.file_list.item(index).item_button.show()
 
         # Button
         button_stopped_style = 'QPushButton { background-color: #5fa416; color: #ffffff; padding: 10px; border: 0; border-radius: 5px; }'


### PR DESCRIPTION
I couldn't find a way to just disable the QPushButtons of each QListWidgetItem, so this was the easy way out.

I hope it isn't bad UX e.g user might be confused why the files are all 'greyed out' once they start the share.