### PR TITLE
[ux-update] set MinimumSize on the word-wrapped QLabels in the SettingsDialog

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -86,12 +86,14 @@ class SettingsDialog(QtWidgets.QDialog):
         stealth_details.setWordWrap(True)
         stealth_details.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
         stealth_details.setOpenExternalLinks(True)
+        stealth_details.setMinimumSize(stealth_details.sizeHint())
         self.stealth_checkbox = QtWidgets.QCheckBox()
         self.stealth_checkbox.setCheckState(QtCore.Qt.Unchecked)
         self.stealth_checkbox.setText(strings._("gui_settings_stealth_option", True))
 
         hidservauth_details = QtWidgets.QLabel(strings._('gui_settings_stealth_hidservauth_string', True))
         hidservauth_details.setWordWrap(True)
+        hidservauth_details.setMinimumSize(hidservauth_details.sizeHint())
         hidservauth_details.hide()
 
         self.hidservauth_copy_button = QtWidgets.QPushButton(strings._('gui_copy_hidservauth', True))


### PR DESCRIPTION
...which prevents them getting squished when parent is resized smaller

Turn on Persistence and Stealth mode, then perform a share. Then stop, and open SettingsDialog. Shrink the SettingsDialog vertically a bit and you'll notice the Stealth and HidServAuth labels get squished.

It turns out that, in general, word wrapped QLabels need to setMinimumHeight() to their sizeHint() . This prevents the issue with the parent layout messing with things. See:

https://stackoverflow.com/questions/25644026/setting-word-wrap-on-qlabel-breaks-size-constrains-for-the-window
https://bugreports.qt.io/browse/QTBUG-37673
http://doc.qt.io/qt-5/layout.html#layout-issues

Have only tested on Linux 