### PR TITLE
[ux-update] Set the URL label to explicitly mention when persistent. 

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -140,16 +140,10 @@ class OnionShareGui(QtWidgets.QMainWindow):
         # Status bar, zip progress bar
         self._zip_progress_bar = None
 
-        # Persistent URL notification
-        self.persistent_url_label = QtWidgets.QLabel(strings._('persistent_url_in_use', True))
-        self.persistent_url_label.setStyleSheet('font-weight: bold; color: #333333;')
-        self.persistent_url_label.hide()
-
         # Primary action layout
         primary_action_layout = QtWidgets.QVBoxLayout()
         primary_action_layout.addWidget(self.server_status)
         primary_action_layout.addWidget(self.filesize_warning)
-        primary_action_layout.addWidget(self.persistent_url_label)
         primary_action_layout.addWidget(self.downloads_container)
         self.primary_action = QtWidgets.QWidget()
         self.primary_action.setLayout(primary_action_layout)
@@ -409,9 +403,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.stop_server()
                 self.start_server_error(strings._('gui_server_started_after_timeout'))
 
-        if self.settings.get('save_private_key'):
-            self.persistent_url_label.show()
-
     def start_server_error(self, error):
         """
         If there's an error when trying to start the onion service
@@ -443,7 +434,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         # Remove ephemeral service, but don't disconnect from Tor
         self.onion.cleanup(stop_tor=False)
         self.filesize_warning.hide()
-        self.persistent_url_label.hide()
         self.stop_server_finished.emit()
 
         self.set_server_active(False)

--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -145,10 +145,15 @@ class ServerStatus(QtWidgets.QWidget):
         if self.status == self.STATUS_STARTED:
             self.url_description.show()
 
-            if self.settings.get('close_after_first_download'):
+            if self.settings.get('save_private_key'):
+                self.url_label.setText(strings._('gui_url_label_persistent', True))
+                self.url_label.setToolTip(strings._('gui_url_persistence_warning', True))
+            elif self.settings.get('close_after_first_download'):
                 self.url_label.setText(strings._('gui_url_label_one_time', True))
+                self.url_label.setToolTip('')
             else:
                 self.url_label.setText(strings._('gui_url_label', True))
+                self.url_label.setToolTip('')
             self.url_label.show()
 
             self.url.setText('http://{0:s}/{1:s}'.format(self.app.onion_host, self.web.slug))

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -133,10 +133,11 @@
     "gui_server_timeout_expired": "The chosen timeout has already expired.\nPlease update the timeout and then you may start sharing.",
     "share_via_onionshare": "Share via OnionShare",
     "gui_save_private_key_checkbox": "Use a persistent address\n(unchecking will delete any saved address)",
-    "persistent_url_in_use": "This share is using a persistent address",
     "gui_url_description": "<b>Anyone</b> with this link can <b>download</b> your files using <b>Tor Browser</b>:",
     "gui_url_label": "Your Download Address",
+    "gui_url_label_persistent": "Your <strong>Persistent</strong> Download Address <em>(what's this?)</em>",
     "gui_url_label_one_time": "Your One-Time Download Address",
+    "gui_url_persistence_warning": "Every share will have the same URL.<br><br>If you want to go back to using one-time URLs, turn off persistence in the Settings.",
     "gui_status_indicator_stopped": "Ready to Share",
     "gui_status_indicator_working": "Starting...",
     "gui_status_indicator_started": "Sharing"


### PR DESCRIPTION
Remove older Persistence warning, which would otherwise appear below the URL labels, to save clutter (lots of text there already..). 

Add ToolTip to explain what Persistence means. Hovering over the URL label will show the tool tip.

The 'close automatically on download' URL label remains as 'Your One-Time Download Address' without tooltip. And with 'close automatically' off, it remains 'Your Download Address' without tooltip too.

Let me know what you think about this.

![screenshot_2018-02-09_07-53-16](https://user-images.githubusercontent.com/99173/35997794-87b4f1a0-0d12-11e8-95b5-3eaa493a5926.png)
