### PR TITLE
Reverse the order of the files when adding them

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -336,7 +336,9 @@ class FileSelection(QtWidgets.QVBoxLayout):
         """
         file_dialog = FileDialog(caption=strings._('gui_choose_items', True))
         if file_dialog.exec_() == QtWidgets.QDialog.Accepted:
-            for filename in file_dialog.selectedFiles():
+            selected_files = file_dialog.selectedFiles()
+            selected_files.sort(reverse=True)
+            for filename in selected_files:
                 self.file_list.add_file(filename)
 
         self.file_list.setCurrentItem(None)


### PR DESCRIPTION
Fixes #604 

Now that file items are QListWidgetItem widgets, the act of 'addWidget()' is putting them into the list in reverse order alphabetically - at least visually.

This means deleting items from the list is actually popping the wrong item from the list.

I couldn't seem to fix this with QListWidget's self.sortItems() despite trying it in various spots.

This fix is counterintuitive and a bit hacky, but basically reverses the order of the filenames when sending to the QListWidget to be added as item widgets. This ensures addWidget() ends up adding the item widgets to the list in the originally intended order, and the correct item should be deleted from the list.