### PR TITLE
Increase the MinimumHeight of the FileList widget to avoid disappearing icons

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -79,7 +79,7 @@ class FileList(QtWidgets.QListWidget):
         self.setAcceptDrops(True)
         self.setIconSize(QtCore.QSize(32, 32))
         self.setSortingEnabled(True)
-        self.setMinimumHeight(200)
+        self.setMinimumHeight(205)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
         self.filenames = []


### PR DESCRIPTION
This seems to fix #607 for me - perhaps the way the widgets are done now was causing the icons to 'disappear'/force a scrollbar (the two seem interlinked) when there's 3 items in the list. (Adding 6 items and deleting a couple would trigger the 'icon disappear' issue)