### PR TITLE
Ensure we don't break out of the loop too early when simultaneous downloads are running and one completes first

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -305,6 +305,7 @@ def download(slug_candidate):
                         sys.stdout.flush()
 
                     add_request(REQUEST_PROGRESS, path, {'id': download_id, 'bytes': downloaded_bytes})
+                    done = False
                 except:
                     # looks like the download was canceled
                     done = True


### PR DESCRIPTION
This seems to fix #614

I think I broke it when I registered 'done' as a global in the web component. This was done so that we could avoid stopping a download that is in progress when the shutdown timer ran out.

But in doing so I think I cause 'done = True' to stick, so that when 1 download finishes, a simultaneous download closes early. Sorry..