### PR TITLE
Fix updating primary action and re-enabling drag-n-drop when a share is canceled

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -79,6 +79,8 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.server_status.server_stopped.connect(self.update_server_status_indicator)
         self.server_status.server_stopped.connect(self.update_primary_action)
         self.server_status.server_canceled.connect(self.cancel_server)
+        self.server_status.server_canceled.connect(self.file_selection.server_stopped)
+        self.server_status.server_canceled.connect(self.update_primary_action)
         self.start_server_finished.connect(self.clear_message)
         self.start_server_finished.connect(self.server_status.start_server_finished)
         self.start_server_finished.connect(self.update_server_status_indicator)


### PR DESCRIPTION
Fixes #618 

I don't think we need to connect to the self.stop_server_finished slot because cancel_server() itself calls stop_server() already.