### PR TITLE
Make the appearance of the download status icons occur consistently with the file info label

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -119,11 +119,12 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         self.info_in_progress_download_count = QtWidgets.QLabel()
         self.info_in_progress_download_count.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
-        self.info_in_progress_download_count.hide()
 
         self.info_completed_downloads_count = QtWidgets.QLabel()
         self.info_completed_downloads_count.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
-        self.info_completed_downloads_count.hide()
+
+        self.update_downloads_completed(self.downloads_in_progress)
+        self.update_downloads_in_progress(self.downloads_in_progress)
 
         self.info_layout.addWidget(self.info_label)
         self.info_layout.addStretch()
@@ -228,6 +229,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         file_count = self.file_selection.file_list.count()
         if file_count > 0:
             self.primary_action.show()
+            self.info_widget.show()
 
             # Update the file count in the info label
             total_size_bytes = 0
@@ -240,7 +242,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.info_label.setText(strings._('gui_file_info', True).format(file_count, total_size_readable))
             else:
                 self.info_label.setText(strings._('gui_file_info_single', True).format(file_count, total_size_readable))
-            self.info_widget.show()
 
         else:
             self.primary_action.hide()
@@ -366,8 +367,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.downloads_container.hide()
         self.downloads.reset_downloads()
         self.reset_info_counters()
-        self.info_in_progress_download_count.show()
-        self.info_completed_downloads_count.show()
         self.status_bar.clearMessage()
         self.server_share_status_label.setText('')
 
@@ -676,8 +675,6 @@ class OnionShareGui(QtWidgets.QMainWindow):
         """
         self.update_downloads_completed(0)
         self.update_downloads_in_progress(0)
-        self.info_in_progress_download_count.show()
-        self.info_completed_downloads_count.show()
 
     def update_downloads_completed(self, count):
         """


### PR DESCRIPTION
There were a couple of minor inconsistencies/redundancies in when the download progress/completed counters/icons were being shown in the 'info' widget at top of screen.

This change makes them appear consistently when the 'file info' QLabel is shown in the same widget.

If you want to test, just check to make sure that:

1) The download icons aren't shown when there are no files added to the File List widget (same as there is no file info label)

2) The download icons are shown as soon as you add one or more files to the list (same as when the file info label appears)

3) That when you stop a share, the counters reset to zero and go gray, but don't disappear. *Edit* actually only ‘in progress’ icon should reset, the ‘downloads completed’ counter remains same as the download progress bars, as an indicator of that previous share’s activity. So that’s normal. Starting a *new* share will reset both counters.

4) That removing all the files from the list hides both the file info label and the download counters

The main issue fixed here was that 2) was not occurring until you actually started the share.