### PR TITLE
File Widget item ordering/deleting/styling fixes

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -191,6 +191,7 @@ class FileList(QtWidgets.QListWidget):
         """
         Add a file or directory to this widget.
         """
+        filenames = []
         for index in range(self.count()):
             filenames.append(self.item(index).filename)
 

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -86,6 +86,7 @@ class FileList(QtWidgets.QListWidget):
         self.drop_here_text = DropHereLabel(self, False)
         self.drop_count = DropCountLabel(self)
         self.resizeEvent(None)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
         self.setStyleSheet('QListWidget::item { color: #000000; font-size: 13px; }')
 
     def update(self):

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -90,7 +90,7 @@ class FileList(QtWidgets.QListWidget):
             """
             QListWidget::item { background-color: #ffffff; color: #000000; font-size: 13px; }
             QListWidget::item:selected { background-color: #ddddff; }
-            QWidget#item-info { background-color: #ffffff; }
+            QWidget#item-info { background-color: #fbfbfb; border: 1px solid #f0f0f0; border-radius: 5px; }
             """
         )
 

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -81,13 +81,18 @@ class FileList(QtWidgets.QListWidget):
         self.setSortingEnabled(True)
         self.setMinimumHeight(205)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-
         self.drop_here_image = DropHereLabel(self, True)
         self.drop_here_text = DropHereLabel(self, False)
         self.drop_count = DropCountLabel(self)
         self.resizeEvent(None)
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
-        self.setStyleSheet('QListWidget::item { color: #000000; font-size: 13px; }')
+        self.setStyleSheet(
+            """
+            QListWidget::item { background-color: #ffffff; color: #000000; font-size: 13px; }
+            QListWidget::item:selected { background-color: #ddddff; }
+            QWidget#item-info { background-color: #ffffff; }
+            """
+        )
 
     def update(self):
         """
@@ -204,8 +209,6 @@ class FileList(QtWidgets.QListWidget):
 
             fileinfo = QtCore.QFileInfo(filename)
             basename = os.path.basename(filename.rstrip('/'))
-            if len(basename) > 35:
-                basename = basename[:35] + '...'
             ip = QtWidgets.QFileIconProvider()
             icon = ip.icon(fileinfo)
 
@@ -242,11 +245,18 @@ class FileList(QtWidgets.QListWidget):
             item.item_button.clicked.connect(delete_item)
             item.item_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
 
+            # Item info widget, with a white background
+            item_info_layout = QtWidgets.QHBoxLayout()
+            item_info_layout.addWidget(item_size)
+            item_info_layout.addWidget(item.item_button)
+            item_info = QtWidgets.QWidget()
+            item_info.setObjectName('item-info')
+            item_info.setLayout(item_info_layout)
+
             # Create the item's widget and layouts
             item_hlayout = QtWidgets.QHBoxLayout()
             item_hlayout.addStretch()
-            item_hlayout.addWidget(item_size)
-            item_hlayout.addWidget(item.item_button)
+            item_hlayout.addWidget(item_info)
             widget = QtWidgets.QWidget()
             widget.setLayout(item_hlayout)
 

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -82,8 +82,6 @@ class FileList(QtWidgets.QListWidget):
         self.setMinimumHeight(205)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
-        self.filenames = []
-
         self.drop_here_image = DropHereLabel(self, True)
         self.drop_here_text = DropHereLabel(self, False)
         self.drop_count = DropCountLabel(self)
@@ -194,9 +192,9 @@ class FileList(QtWidgets.QListWidget):
         Add a file or directory to this widget.
         """
         for index in range(self.count()):
-            self.filenames.append(self.item(index))
+            filenames.append(self.item(index).filename)
 
-        if filename not in self.filenames:
+        if filename not in filenames:
             if not os.access(filename, os.R_OK):
                 Alert(strings._("not_a_readable_file", True).format(filename))
                 return

--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -86,6 +86,7 @@ class FileList(QtWidgets.QListWidget):
         self.drop_here_text = DropHereLabel(self, False)
         self.drop_count = DropCountLabel(self)
         self.resizeEvent(None)
+        self.setStyleSheet('QListWidget::item { color: #000000; font-size: 13px; }')
 
     def update(self):
         """
@@ -202,6 +203,8 @@ class FileList(QtWidgets.QListWidget):
 
             fileinfo = QtCore.QFileInfo(filename)
             basename = os.path.basename(filename.rstrip('/'))
+            if len(basename) > 35:
+                basename = basename[:35] + '...'
             ip = QtWidgets.QFileIconProvider()
             icon = ip.icon(fileinfo)
 
@@ -217,20 +220,13 @@ class FileList(QtWidgets.QListWidget):
             item.setIcon(icon)
             item.size_bytes = size_bytes
 
-            # Item's name and size labels
-            item_name = QtWidgets.QLabel(basename)
+            # Item's filename attribute and size labels
             item.filename = filename
-            item_name.setWordWrap(False)
-            item_name.setSizePolicy(QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed)
-            item_name.setStyleSheet('QLabel { color: #000000; font-size: 13px; }')
             item_size = QtWidgets.QLabel(size_readable)
             item_size.setStyleSheet('QLabel { color: #666666; font-size: 11px; }')
 
             # Use the basename as the method with which to sort the list
             item.setData(QtCore.Qt.DisplayRole, basename)
-            # But we don't want to *display* the QString (we have our own QLabel), so paint over it.
-            item.brush = QtGui.QBrush(QtGui.QColor('white'))
-            item.setForeground(item.brush)
 
             # Item's delete button
             def delete_item():
@@ -246,11 +242,9 @@ class FileList(QtWidgets.QListWidget):
             item.item_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
 
             # Create the item's widget and layouts
-            item_vlayout = QtWidgets.QVBoxLayout()
-            item_vlayout.addWidget(item_name)
-            item_vlayout.addWidget(item_size)
             item_hlayout = QtWidgets.QHBoxLayout()
-            item_hlayout.addLayout(item_vlayout)
+            item_hlayout.addStretch()
+            item_hlayout.addWidget(item_size)
             item_hlayout.addWidget(item.item_button)
             widget = QtWidgets.QWidget()
             widget.setLayout(item_hlayout)

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -410,8 +410,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         # add progress bar to the status bar, indicating the crunching of files.
         self._zip_progress_bar = ZipProgressBar(0)
-        self._zip_progress_bar.total_files_size = OnionShareGui._compute_total_size(
-            self.file_selection.file_list.filenames)
+        self.filenames = []
+        for index in range(self.file_selection.file_list.count()):
+            self.filenames.append(self.file_selection.file_list.item(index).filename)
+
+        self._zip_progress_bar.total_files_size = OnionShareGui._compute_total_size(self.filenames)
         self.status_bar.insertWidget(0, self._zip_progress_bar)
 
         # prepare the files for sending in a new thread
@@ -421,7 +424,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 if self._zip_progress_bar != None:
                     self._zip_progress_bar.update_processed_size_signal.emit(x)
             try:
-                web.set_file_info(self.file_selection.file_list.filenames, processed_size_callback=_set_processed_size)
+                web.set_file_info(self.filenames, processed_size_callback=_set_processed_size)
                 self.app.cleanup_filenames.append(web.zip_filename)
                 self.starting_server_step3.emit()
 


### PR DESCRIPTION
Use the QListWidgetItems for building up lists of filename (for deleting the right item from the list). (Fixes #604)

Fix styling relating to the item widgets and long filenames.