### PR TITLE
Fix get_num_files() to count the items in the QListWidget, not in the FileSelection QVBoxLayout widget

### DIFF
--- a/onionshare_gui/file_selection.py
+++ b/onionshare_gui/file_selection.py
@@ -369,7 +369,7 @@ class FileSelection(QtWidgets.QVBoxLayout):
         """
         Returns the total number of files and folders in the list.
         """
-        return len(range(self.count()))
+        return len(range(self.file_list.count()))
 
     def setFocus(self):
         """


### PR DESCRIPTION
An obscure bug that didn't cause any regressions in the UI (since we only ever check if this value is > 0), but broke one of my GUI tests whereby I add a file and expected get_num_files() to return 1, but it was returning 2 because we were counting the number of items in the wrong widget.

