### PR TITLE
Fix typo bug that is only triggered if obfs4proxy binary is not found

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -169,7 +169,7 @@ class SettingsDialog(QtWidgets.QDialog):
         (self.tor_path, self.tor_geo_ip_file_path, self.tor_geo_ipv6_file_path, self.obfs4proxy_file_path) = common.get_tor_paths()
         if not os.path.isfile(self.obfs4proxy_file_path):
             self.tor_bridges_use_meek_lite_amazon_radio = QtWidgets.QRadioButton(strings._('gui_settings_tor_bridges_meek_lite_amazon_radio_option_no_obfs4proxy', True))
-            self.tor_bridges_use_meel_lite_amazon_radio.setEnabled(False)
+            self.tor_bridges_use_meek_lite_amazon_radio.setEnabled(False)
         else:
             self.tor_bridges_use_meek_lite_amazon_radio = QtWidgets.QRadioButton(strings._('gui_settings_tor_bridges_meek_lite_amazon_radio_option', True))
         self.tor_bridges_use_meek_lite_amazon_radio.toggled.connect(self.tor_bridges_use_meek_lite_amazon_radio_toggled)
@@ -179,7 +179,7 @@ class SettingsDialog(QtWidgets.QDialog):
         (self.tor_path, self.tor_geo_ip_file_path, self.tor_geo_ipv6_file_path, self.obfs4proxy_file_path) = common.get_tor_paths()
         if not os.path.isfile(self.obfs4proxy_file_path):
             self.tor_bridges_use_meek_lite_azure_radio = QtWidgets.QRadioButton(strings._('gui_settings_tor_bridges_meek_lite_azure_radio_option_no_obfs4proxy', True))
-            self.tor_bridges_use_meel_lite_azure_radio.setEnabled(False)
+            self.tor_bridges_use_meek_lite_azure_radio.setEnabled(False)
         else:
             self.tor_bridges_use_meek_lite_azure_radio = QtWidgets.QRadioButton(strings._('gui_settings_tor_bridges_meek_lite_azure_radio_option', True))
         self.tor_bridges_use_meek_lite_azure_radio.toggled.connect(self.tor_bridges_use_meek_lite_azure_radio_toggled)
@@ -494,7 +494,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
     def tor_bridges_use_meek_lite_azure_radio_toggled(self, checked):
         """
-        meel_lite_azure bridges option was toggled. If checked, disable custom bridge options.
+        meek_lite_azure bridges option was toggled. If checked, disable custom bridge options.
         """
         if checked:
             self.tor_bridges_use_custom_textbox_options.hide()


### PR DESCRIPTION
I was setting up a new Windows build environment, and I ran `python dev_scripts\onionshare-gui`. It crashed with this error:

```
[Feb 24 2018 14:06:19] OnionShareGui._tor_connection_open_settings
[Feb 24 2018 14:06:19] OnionShareGui.open_settings
[Feb 24 2018 14:06:19] SettingsDialog.__init__
Traceback (most recent call last):
  File "C:\Users\Micah Lee\code\onionshare\onionshare_gui\onionshare_gui.py", line 242, in open_settings
    d = SettingsDialog(self.onion, self.qtapp, self.config)
  File "C:\Users\Micah Lee\code\onionshare\onionshare_gui\settings_dialog.py", line 164, in __init__
    self.tor_bridges_use_meel_lite_amazon_radio.setEnabled(False)
AttributeError: 'SettingsDialog' object has no attribute 'tor_bridges_use_meel_lite_amazon_radio'
```

The problem was a typo in the source code.