### PR TITLE
Remove use of `re` module by using `str.endswith`

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -23,7 +23,6 @@ import inspect
 import os
 import platform
 import random
-import re
 import socket
 import sys
 import tempfile
@@ -58,9 +57,10 @@ def get_platform():
     Returns the platform OnionShare is running on.
     """
     plat = platform.system() 
-    if re.match('^.*BSD$', plat):
+    if plat.endswith('BSD'):
         plat = 'BSD'
     return plat
+
 
 def get_resource_path(filename):
     """


### PR DESCRIPTION
https://github.com/micahflee/onionshare/blob/aafebff0c356c923700528d7f318b80fbb1cbee1/onionshare/common.py#L61

The current regular expression seems to only be checking whether or not a string ends with `"BSD"`. Using `str.endswith` instead removes the need for importing `re`.

```python
>>> import re
... 
... fake_platforms = ('oneBSD', 'TWOBSD', 'ThReeBSD', 'windows', 'linux')
... for plat in fake_platforms:
...     print(f"{plat}: {bool(re.match('^.*BSD$', plat))} {plat.endswith('BSD')}")
... 
oneBSD: True True
TWOBSD: True True
ThReeBSD: True True
windows: False False
linux: False False

```