### PR TITLE
Fix the broken images in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pip-log.txt
 .tox
 nosetests.xml
 .cache
+.pytest_cache
 
 # Translations
 *.mo

--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -57,7 +57,7 @@ def get_platform():
     """
     Returns the platform OnionShare is running on.
     """
-    plat = platform.system() 
+    plat = platform.system()
     if re.match('^.*BSD$', plat):
         plat = 'BSD'
     return plat
@@ -68,6 +68,10 @@ def get_resource_path(filename):
     systemwide, and whether regardless of platform
     """
     p = get_platform()
+
+    # On Windows, and in Windows dev mode, switch slashes in incoming filename to backslackes
+    if p == 'Windows':
+        filename = filename.replace('/', '\\')
 
     if getattr(sys, 'onionshare_dev_mode', False):
         # Look for resources directory relative to python file

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -684,7 +684,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
             self.info_completed_downloads_image = common.get_resource_path('images/download_completed_none.png')
         else:
             self.info_completed_downloads_image = common.get_resource_path('images/download_completed.png')
-        self.info_completed_downloads_count.setText('<img src={0:s} /> {1:d}'.format(self.info_completed_downloads_image, count))
+        self.info_completed_downloads_count.setText('<img src="{0:s}" /> {1:d}'.format(self.info_completed_downloads_image, count))
         self.info_completed_downloads_count.setToolTip(strings._('info_completed_downloads_tooltip', True).format(count))
 
     def update_downloads_in_progress(self, count):
@@ -695,7 +695,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
             self.info_in_progress_downloads_image = common.get_resource_path('images/download_in_progress_none.png')
         else:
             self.info_in_progress_downloads_image = common.get_resource_path('images/download_in_progress.png')
-        self.info_in_progress_downloads_count.setText('<img src={0:s} /> {1:d}'.format(self.info_in_progress_downloads_image, count))
+        self.info_in_progress_downloads_count.setText('<img src="{0:s}" /> {1:d}'.format(self.info_in_progress_downloads_image, count))
         self.info_in_progress_downloads_count.setToolTip(strings._('info_in_progress_downloads_tooltip', True).format(count))
 
     def closeEvent(self, e):

--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -116,8 +116,8 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.info_label = QtWidgets.QLabel()
         self.info_label.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
 
-        self.info_in_progress_download_count = QtWidgets.QLabel()
-        self.info_in_progress_download_count.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
+        self.info_in_progress_downloads_count = QtWidgets.QLabel()
+        self.info_in_progress_downloads_count.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
 
         self.info_completed_downloads_count = QtWidgets.QLabel()
         self.info_completed_downloads_count.setStyleSheet('QLabel { font-size: 12px; color: #666666; }')
@@ -127,7 +127,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
         self.info_layout.addWidget(self.info_label)
         self.info_layout.addStretch()
-        self.info_layout.addWidget(self.info_in_progress_download_count)
+        self.info_layout.addWidget(self.info_in_progress_downloads_count)
         self.info_layout.addWidget(self.info_completed_downloads_count)
 
         self.info_widget = QtWidgets.QWidget()
@@ -692,11 +692,11 @@ class OnionShareGui(QtWidgets.QMainWindow):
         Update the 'Downloads in progress' info widget.
         """
         if count == 0:
-            self.info_in_progress_download_image = common.get_resource_path('images/download_in_progress_none.png')
+            self.info_in_progress_downloads_image = common.get_resource_path('images/download_in_progress_none.png')
         else:
-            self.info_in_progress_download_image = common.get_resource_path('images/download_in_progress.png')
-        self.info_in_progress_download_count.setText('<img src={0:s} /> {1:d}'.format(self.info_in_progress_download_image, count))
-        self.info_in_progress_download_count.setToolTip(strings._('info_in_progress_downloads_tooltip', True).format(count))
+            self.info_in_progress_downloads_image = common.get_resource_path('images/download_in_progress.png')
+        self.info_in_progress_downloads_count.setText('<img src={0:s} /> {1:d}'.format(self.info_in_progress_downloads_image, count))
+        self.info_in_progress_downloads_count.setToolTip(strings._('info_in_progress_downloads_tooltip', True).format(count))
 
     def closeEvent(self, e):
         common.log('OnionShareGui', 'closeEvent')

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -141,7 +141,7 @@
     "gui_server_timeout_expired": "The chosen timeout has already expired.\nPlease update the timeout and then you may start sharing.",
     "share_via_onionshare": "Share via OnionShare",
     "gui_save_private_key_checkbox": "Use a persistent address\n(unchecking will delete any saved address)",
-    "gui_url_description": "<b>Anyone</b> with this link can <b>download</b> your files using <b>Tor Browser</b>: <img src={} />",
+    "gui_url_description": "<b>Anyone</b> with this link can <b>download</b> your files using <b>Tor Browser</b>: <img src='{}' />",
     "gui_url_label_persistent": "This share will not stop automatically unless a timer is set.<br><br>Every share will have the same address (to use one-time addresses, disable persistence in the Settings)",
     "gui_url_label_stay_open": "This share will not stop automatically unless a timer is set.",
     "gui_url_label_onetime": "This share will stop after the first download",

--- a/test/test_onionshare_common.py
+++ b/test/test_onionshare_common.py
@@ -193,12 +193,6 @@ class TestGetResourcePath:
             common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
             os.path.join(prefix, 'test_filename'))
 
-    def test_frozen_windows(self, platform_windows, sys_frozen):
-        prefix = os.path.join(os.path.dirname(sys.executable), 'share')
-        assert (
-            common.get_resource_path(os.path.join(prefix, 'test_filename')) ==
-            os.path.join(prefix, 'test_filename'))
-
 
 class TestGetTorPaths:
     # @pytest.mark.skipif(sys.platform != 'Darwin', reason='requires MacOS') ?


### PR DESCRIPTION
Fixes #641.

The problem is (at least my problem when I ran into it) is that the image path filename had spaces in it, and if you're specifying the src of an `<img>` tag, you need to use quotes. This seems to fix the issue.