### PR TITLE
Add ability to abort but not exit SettingsDialog/reconnect to Tor, on invalid settings. Do this for invalid bridges

### DIFF
--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -106,7 +106,7 @@
     "gui_settings_tor_bridges_meek_lite_azure_radio_option_no_obfs4proxy": "Use built-in meek_lite (Azure) pluggable transports (requires obfs4proxy)",
     "gui_settings_tor_bridges_custom_radio_option": "Use custom bridges",
     "gui_settings_tor_bridges_custom_label": "You can get bridges from <a href=\"https://bridges.torproject.org/options\">https://bridges.torproject.org</a>",
-    "gui_settings_tor_bridges_invalid": "None of the bridges you supplied seem to be valid, so they've been ignored.\nPlease try again with valid bridges.",
+    "gui_settings_tor_bridges_invalid": "None of the bridges you supplied seem to be valid.\nPlease try again with valid bridges.",
     "gui_settings_button_save": "Save",
     "gui_settings_button_cancel": "Cancel",
     "gui_settings_button_help": "Help",


### PR DESCRIPTION
Here's something that fixes #634 (please test the hell out of it, it's late here and I've had a glass of wine, so migressions might be rampant)

This diff looks bigger than it really is, but it's just a code indentation.

Previously, no matter what, clicking 'Save' on SettingsDialog always emitted 'save clicked', which invoked the 'save_clicked' function, which always attempted to reconnect to Tor with the settings provided, and closed the SettingsDialog.

All this change does, is first check if the settings_from_fields() function actually returned something other than False, in which case do what it always did (as above). But if it returned False, do nothing, meaning that the SettingsDialog stays open.

And in doing so, we now explicitly return False on invalid custom bridges, which solves #634 . The user receives the same alert dialog, but remains in the SettingsDialog to correct the issue. 

~~Note that I still force it to save 'no_bridges' in the settings before returning False, because otherwise, if you click Cancel on the SettingsDialog, then next time you open OnionShare and the SettingsDialog, *none* of the bridge options are selected (but neither is 'Don't use bridges'), which is 'unnatural' - a radio option should always be selected. So we should still be setting 'no bridges' as the default if the user backs out via Cancel altogether (in doing so, we return to the default mode that OnionShare ships with: bundled mode, no bridges).~~

Edit I realise I'm wrong on the last paragraph, but maybe it's not that big a deal.. the issue being that settings.save() only occurs if settings_from_fields() returned True.. but in a way this is good: if you previously had valid custom bridges, and then you entered bad ones, and then you ignored the Alert and clicked Cancel, at least your settings preserve the original valid bridges..
