### PR TITLE
Move cmdline parsing to separate function

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -18,11 +18,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import argparse
 import os
 import sys
 import threading
 import time
+from argparse import ArgumentParser, FileType, HelpFormatter
 
 from . import strings, common, web
 from .onion import (
@@ -43,10 +43,37 @@ from .onionshare import OnionShare
 from .settings import Settings
 
 
+def _parse_cmdline_args():
+    parser = ArgumentParser(
+        formatter_class=lambda prog: HelpFormatter(prog, max_help_position=28))
+    parser.add_argument(
+        '--local-only', action='store_true',
+        help=strings._("help_local_only"))
+    parser.add_argument(
+        '--stay-open', action='store_true',
+        help=strings._("help_stay_open"))
+    parser.add_argument(
+        '--shutdown-timeout', metavar='<int>', default=0, type=int,
+        help=strings._("help_shutdown_timeout"))
+    parser.add_argument(
+        '--stealth', action='store_true',
+        help=strings._("help_stealth"))
+    parser.add_argument(
+        '--debug', action='store_true',
+        help=strings._("help_debug"))
+    parser.add_argument(
+        '--config', metavar='config', default=False, type=FileType('r'),
+        help=strings._('help_config'))
+    parser.add_argument(
+        'filename', metavar='filename', nargs='+', type=FileType('r'),
+        help=strings._('help_filename'))
+    return parser.parse_args()
+
+
 def main(cwd=None):
     """
-    The main() function implements all of the logic that the command-line version of
-    onionshare uses.
+    The main() function implements all of the logic that the
+    command-line version of onionshare uses.
     """
     strings.load_strings(common)
     print(strings._('version_string').format(common.get_version()))
@@ -56,52 +83,39 @@ def main(cwd=None):
         if cwd:
             os.chdir(cwd)
 
-    # Parse arguments
-    parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=28))
-    parser.add_argument('--local-only', action='store_true', dest='local_only', help=strings._("help_local_only"))
-    parser.add_argument('--stay-open', action='store_true', dest='stay_open', help=strings._("help_stay_open"))
-    parser.add_argument('--shutdown-timeout', metavar='<int>', dest='shutdown_timeout', default=0, help=strings._("help_shutdown_timeout"))
-    parser.add_argument('--stealth', action='store_true', dest='stealth', help=strings._("help_stealth"))
-    parser.add_argument('--debug', action='store_true', dest='debug', help=strings._("help_debug"))
-    parser.add_argument('--config', metavar='config', default=False, help=strings._('help_config'))
-    parser.add_argument('filename', metavar='filename', nargs='+', help=strings._('help_filename'))
-    args = parser.parse_args()
+    args = _parse_cmdline_args()
 
-    filenames = args.filename
-    for i in range(len(filenames)):
-        filenames[i] = os.path.abspath(filenames[i])
+    filenames = []
+    for f in args.filename:
+        filenames.append(os.path.abspath(f.name))
+        f.close()
 
-    local_only = bool(args.local_only)
-    debug = bool(args.debug)
-    stay_open = bool(args.stay_open)
-    shutdown_timeout = int(args.shutdown_timeout)
-    stealth = bool(args.stealth)
-    config = args.config
+    if args.config:
+        args.config.close()
+        args.config = args.config.name
 
     # Debug mode?
-    if debug:
-        common.set_debug(debug)
+    if args.debug:
+        common.set_debug(True)
         web.debug_mode()
 
-    # Validation
-    valid = True
-    for filename in filenames:
-        if not os.path.isfile(filename) and not os.path.isdir(filename):
-            print(strings._("not_a_file").format(filename))
-            valid = False
-        if not os.access(filename, os.R_OK):
-            print(strings._("not_a_readable_file").format(filename))
-            valid = False
-    if not valid:
-        sys.exit()
-
-    settings = Settings(config)
+    settings = Settings(args.config)
 
     # Start the Onion object
     onion = Onion()
     try:
-        onion.connect(settings=False, config=config)
-    except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorNotSupported, BundledTorTimeout) as e:
+        onion.connect(settings=False, config=args.config)
+    except (BundledTorNotSupported,
+            BundledTorTimeout,
+            TorErrorAuthError,
+            TorErrorAutomatic,
+            TorErrorInvalidSetting,
+            TorErrorMissingPassword,
+            TorErrorProtocolError,
+            TorErrorSocketFile,
+            TorErrorSocketPort,
+            TorErrorUnreadableCookieFile,
+            TorTooOld) as e:
         sys.exit(e.args[0])
     except KeyboardInterrupt:
         print("")
@@ -109,8 +123,12 @@ def main(cwd=None):
 
     # Start the onionshare app
     try:
-        app = OnionShare(onion, local_only, stay_open, shutdown_timeout)
-        app.set_stealth(stealth)
+        app = OnionShare(
+            onion,
+            args.local_only,
+            args.stay_open,
+            args.shutdown_timeout)
+        app.set_stealth(args.stealth)
         app.start_onion_service()
     except KeyboardInterrupt:
         print("")
@@ -133,7 +151,9 @@ def main(cwd=None):
 
     # Start OnionShare http service in new thread
     settings.load()
-    t = threading.Thread(target=web.start, args=(app.port, app.stay_open, settings.get('slug')))
+    t = threading.Thread(
+        target=web.start,
+        args=(app.port, app.stay_open, settings.get('slug')))
     t.daemon = True
     t.start()
 
@@ -151,7 +171,7 @@ def main(cwd=None):
                 settings.set('slug', web.slug)
                 settings.save()
 
-        if stealth:
+        if args.stealth:
             print(strings._("give_this_url_stealth"))
             print('http://{0:s}/{1:s}'.format(app.onion_host, web.slug))
             print(app.auth_string)

--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -18,12 +18,30 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os, sys, time, argparse, threading
+import argparse
+import os
+import sys
+import threading
+import time
 
 from . import strings, common, web
-from .onion import *
+from .onion import (
+    BundledTorNotSupported,
+    BundledTorTimeout,
+    Onion,
+    TorErrorAuthError,
+    TorErrorAutomatic,
+    TorErrorInvalidSetting,
+    TorErrorMissingPassword,
+    TorErrorProtocolError,
+    TorErrorSocketFile,
+    TorErrorSocketPort,
+    TorErrorUnreadableCookieFile,
+    TorTooOld
+)
 from .onionshare import OnionShare
 from .settings import Settings
+
 
 def main(cwd=None):
     """
@@ -39,7 +57,7 @@ def main(cwd=None):
             os.chdir(cwd)
 
     # Parse arguments
-    parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog,max_help_position=28))
+    parser = argparse.ArgumentParser(formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=28))
     parser.add_argument('--local-only', action='store_true', dest='local_only', help=strings._("help_local_only"))
     parser.add_argument('--stay-open', action='store_true', dest='stay_open', help=strings._("help_stay_open"))
     parser.add_argument('--shutdown-timeout', metavar='<int>', dest='shutdown_timeout', default=0, help=strings._("help_shutdown_timeout"))
@@ -76,7 +94,6 @@ def main(cwd=None):
             valid = False
     if not valid:
         sys.exit()
-
 
     settings = Settings(config)
 
@@ -134,7 +151,7 @@ def main(cwd=None):
                 settings.set('slug', web.slug)
                 settings.save()
 
-        if(stealth):
+        if stealth:
             print(strings._("give_this_url_stealth"))
             print('http://{0:s}/{1:s}'.format(app.onion_host, web.slug))
             print(app.auth_string)
@@ -163,6 +180,7 @@ def main(cwd=None):
         # Shutdown
         app.cleanup()
         onion.cleanup()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is just a little experiment to try and break up some of these long functions into smaller functions (starting with command-line parsing). Although I think there could be a few more functions pulled out of `main`, I wanted to see what the reaction would be to this smaller PR first.

* Replaced the `*` import to be more explicit
    ```python
    from .onion import *

    # VS

    from .onion import (
        BundledTorNotSupported,
        BundledTorTimeout,
        Onion,
        TorErrorAuthError,
        TorErrorAutomatic,
        TorErrorInvalidSetting,
        TorErrorMissingPassword,
        TorErrorProtocolError,
        TorErrorSocketFile,
        TorErrorSocketPort,
        TorErrorUnreadableCookieFile,
        TorTooOld
    )
    ```
    [Wildcard imports (from <module> import *) should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools.
](http://pep8.org/#imports)
* Remove `dest` parameters since they were only returning the defaults anyways

    ```python
    >>> from argparse import ArgumentParser
    >>> parser = ArgumentParser()
    >>> parser.add_argument('--local-only')  # dest='local_only' unnecessary
    _StoreAction(option_strings=['--local_only'], dest='local_only', nargs=None, const=None, default=None, type=None, choices=None, help=None, metavar=None)
                                                  ^^^^^^^^^^^^^^^^^
    ```

    [For optional argument actions, the value of `dest` is normally inferred from the option strings. `ArgumentParser` generates the value of `dest` by taking the first long option string and stripping away the initial -- string. If no long option strings were supplied, `dest` will be derived from the first short option string by stripping the initial - character. Any internal - characters will be converted to _ characters to make sure the string is a valid attribute name.](https://docs.python.org/3/library/argparse.html#dest)

* Use `type=int` to ensure that `--shutdown-timeout` is given as an integer. Currently, a string could be given which would raise a `ValueError` on this line: 
    ```python
    shutdown_timeout = int(args.shutdown_timeout)
    ```
    Not a big problem but using `type=int` will raise this clear error message as soon as a non-integer is passed in.

    ```python
    >>> from argparse import ArgumentParser
    >>> parser = ArgumentParser()
    >>> parser.add_argument('--shutdown-timeout', default=0, type=int)
    _StoreAction(option_strings=['--shutdown-timeout'], dest='shutdown_timeout', nargs=None, const=None, default=0, type=<class 'int'>, choices=None, help=None, metavar=None)

    >>> parser.parse_args(['--shutdown-timeout', 'NON_INTEGER'])
    usage: pydevconsole.py [-h] [--shutdown-timeout SHUTDOWN_TIMEOUT]
    pydevconsole.py: error: argument --shutdown-timeout: invalid int value: 'NON_INTEGER'
    ```

* Use `type=FileType('r')` for both `--config` and `filename` to ensure only readable files can be passed in. Letting `argparse` take care of this allows the "Validation" code to be removed.

    ```python
    >>> from argparse import ArgumentParser, FileType
    >>> parser = ArgumentParser()
    >>> parser.add_argument('filename', type=FileType('r'))
    _StoreAction(option_strings=[], dest='filename', nargs=None, const=None, default=None, type=FileType('r'), choices=None, help=None, metavar=None)

    >>> parser.parse_args(['README.md'])
    Namespace(filename=<_io.TextIOWrapper name='README.md' mode='r' encoding='UTF-8'>)

    >>> parser.parse_args(['no_file'])
    usage: pydevconsole.py [-h] filename
    pydevconsole.py: error: argument filename: can't open 'no_file': [Errno 2] No such file or directory: 'no_file'

    >>> parser.parse_args(['test'])
    usage: pydevconsole.py [-h] filename
    pydevconsole.py: error: argument filename: can't open 'test': [Errno 21] Is a directory: 'test'

    ```
* Alphabetize and format exceptions for readability. I know it adds a few lines but it just seemed a bit better than having to scroll far to the right to see all the exceptions.

    ```python
    except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorNotSupported, BundledTorTimeout) as e:

    # VS

    except (BundledTorNotSupported,
            BundledTorTimeout,
            TorErrorAuthError,
            TorErrorAutomatic,
            TorErrorInvalidSetting,
            TorErrorMissingPassword,
            TorErrorProtocolError,
            TorErrorSocketFile,
            TorErrorSocketPort,
            TorErrorUnreadableCookieFile,
            TorTooOld) as e:
    ```

* This section of code was almost entirely redundant since most of the arguments were already the types they were being cast into here.

    ```python
    local_only = bool(args.local_only)  # already a boolean
    debug = bool(args.debug)  # already a boolean
    stay_open = bool(args.stay_open)  # already a boolean
    shutdown_timeout = int(args.shutdown_timeout)  # error if non-integer, fixed by `type=int` above
    stealth = bool(args.stealth)   # already a boolean
    config = args.config
    ```

Anyways, let me know what you guys think!
