### PR TITLE
#662 Allow local-only mode in GUI

### DIFF
--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -108,7 +108,7 @@ def main():
     app = OnionShare(onion, local_only, stay_open, shutdown_timeout)
 
     # Launch the gui
-    gui = OnionShareGui(onion, qtapp, app, filenames, config)
+    gui = OnionShareGui(onion, qtapp, app, filenames, config, local_only)
 
     # Clean up when app quits
     def shutdown():

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -34,13 +34,14 @@ class SettingsDialog(QtWidgets.QDialog):
     """
     settings_saved = QtCore.pyqtSignal()
 
-    def __init__(self, onion, qtapp, config=False):
+    def __init__(self, onion, qtapp, config=False, local_only=False):
         super(SettingsDialog, self).__init__()
         common.log('SettingsDialog', '__init__')
 
         self.onion = onion
         self.qtapp = qtapp
         self.config = config
+        self.local_only = local_only
 
         self.setModal(True)
         self.setWindowTitle(strings._('gui_settings_window_title', True))
@@ -671,48 +672,52 @@ class SettingsDialog(QtWidgets.QDialog):
             # If Tor isn't connected, or if Tor settings have changed, Reinitialize
             # the Onion object
             reboot_onion = False
-            if self.onion.is_authenticated():
-                common.log('SettingsDialog', 'save_clicked', 'Connected to Tor')
-                def changed(s1, s2, keys):
-                    """
-                    Compare the Settings objects s1 and s2 and return true if any values
-                    have changed for the given keys.
-                    """
-                    for key in keys:
-                        if s1.get(key) != s2.get(key):
-                            return True
-                    return False
+            if not self.local_only:
+                if self.onion.is_authenticated():
+                    common.log('SettingsDialog', 'save_clicked', 'Connected to Tor')
+                    def changed(s1, s2, keys):
+                        """
+                        Compare the Settings objects s1 and s2 and return true if any values
+                        have changed for the given keys.
+                        """
+                        for key in keys:
+                            if s1.get(key) != s2.get(key):
+                                return True
+                        return False
 
-                if changed(settings, self.old_settings, [
-                    'connection_type', 'control_port_address',
-                    'control_port_port', 'socks_address', 'socks_port',
-                    'socket_file_path', 'auth_type', 'auth_password',
-                    'no_bridges', 'tor_bridges_use_obfs4',
-                    'tor_bridges_use_meek_lite_amazon', 'tor_bridges_use_meek_lite_azure',
-                    'tor_bridges_use_custom_bridges']):
+                    if changed(settings, self.old_settings, [
+                        'connection_type', 'control_port_address',
+                        'control_port_port', 'socks_address', 'socks_port',
+                        'socket_file_path', 'auth_type', 'auth_password',
+                        'no_bridges', 'tor_bridges_use_obfs4',
+                        'tor_bridges_use_meek_lite_amazon', 'tor_bridges_use_meek_lite_azure',
+                        'tor_bridges_use_custom_bridges']):
 
+                        reboot_onion = True
+
+                else:
+                    common.log('SettingsDialog', 'save_clicked', 'Not connected to Tor')
+                    # Tor isn't connected, so try connecting
                     reboot_onion = True
 
-            else:
-                common.log('SettingsDialog', 'save_clicked', 'Not connected to Tor')
-                # Tor isn't connected, so try connecting
-                reboot_onion = True
+                # Do we need to reinitialize Tor?
+                if reboot_onion:
+                    # Reinitialize the Onion object
+                    common.log('SettingsDialog', 'save_clicked', 'rebooting the Onion')
+                    self.onion.cleanup()
 
-            # Do we need to reinitialize Tor?
-            if reboot_onion:
-                # Reinitialize the Onion object
-                common.log('SettingsDialog', 'save_clicked', 'rebooting the Onion')
-                self.onion.cleanup()
+                    tor_con = TorConnectionDialog(self.qtapp, settings, self.onion)
+                    tor_con.start()
 
-                tor_con = TorConnectionDialog(self.qtapp, settings, self.onion)
-                tor_con.start()
+                    common.log('SettingsDialog', 'save_clicked', 'Onion done rebooting, connected to Tor: {}'.format(self.onion.connected_to_tor))
 
-                common.log('SettingsDialog', 'save_clicked', 'Onion done rebooting, connected to Tor: {}'.format(self.onion.connected_to_tor))
+                    if self.onion.is_authenticated() and not tor_con.wasCanceled():
+                        self.settings_saved.emit()
+                        self.close()
 
-                if self.onion.is_authenticated() and not tor_con.wasCanceled():
+                else:
                     self.settings_saved.emit()
                     self.close()
-
             else:
                 self.settings_saved.emit()
                 self.close()
@@ -856,11 +861,12 @@ class SettingsDialog(QtWidgets.QDialog):
         common.log('SettingsDialog', 'closeEvent')
 
         # On close, if Tor isn't connected, then quit OnionShare altogether
-        if not self.onion.is_authenticated():
-            common.log('SettingsDialog', 'closeEvent', 'Closing while not connected to Tor')
+        if not self.local_only:
+            if not self.onion.is_authenticated():
+                common.log('SettingsDialog', 'closeEvent', 'Closing while not connected to Tor')
 
-            # Wait 1ms for the event loop to finish, then quit
-            QtCore.QTimer.singleShot(1, self.qtapp.quit)
+                # Wait 1ms for the event loop to finish, then quit
+                QtCore.QTimer.singleShot(1, self.qtapp.quit)
 
     def _update_autoupdate_timestamp(self, autoupdate_timestamp):
         common.log('SettingsDialog', '_update_autoupdate_timestamp')


### PR DESCRIPTION
Let me know if this fixes #662 for you @micahflee ?

I'm basically pulling the local_only flag into various elements of the GUI so that various things get ignored (don't connect to Tor, don't 'reboot' Onion when settings change in SettingsDialog, don't alert when Tor is disconnected/authenticated, etc)