### PR TITLE
Rearrange settings

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -309,22 +309,21 @@ class SettingsDialog(QtWidgets.QDialog):
         connection_type_radio_group = QtWidgets.QGroupBox(strings._("gui_settings_connection_type_label", True))
         connection_type_radio_group.setLayout(connection_type_radio_group_layout)
 
-        # Connection type layout
-        connection_type_group_layout = QtWidgets.QVBoxLayout()
-        connection_type_group_layout.addWidget(self.connection_type_control_port_extras)
-        connection_type_group_layout.addWidget(self.connection_type_socket_file_extras)
-        connection_type_group_layout.addWidget(self.connection_type_socks)
-        connection_type_group_layout.addWidget(self.authenticate_group)
-        connection_type_group_layout.addWidget(self.connection_type_test_button)
-        connection_type_group = QtWidgets.QGroupBox()
-        connection_type_group.setLayout(connection_type_group_layout)
-
         # The Bridges options are not exclusive (enabling Bridges offers obfs4 or custom bridges)
         connection_type_bridges_radio_group_layout = QtWidgets.QVBoxLayout()
         connection_type_bridges_radio_group_layout.addWidget(self.bridges)
         self.connection_type_bridges_radio_group = QtWidgets.QGroupBox(strings._("gui_settings_tor_bridges", True))
         self.connection_type_bridges_radio_group.setLayout(connection_type_bridges_radio_group_layout)
         self.connection_type_bridges_radio_group.hide()
+
+        # Connection type layout
+        connection_type_layout = QtWidgets.QVBoxLayout()
+        connection_type_layout.addWidget(self.connection_type_control_port_extras)
+        connection_type_layout.addWidget(self.connection_type_socket_file_extras)
+        connection_type_layout.addWidget(self.connection_type_socks)
+        connection_type_layout.addWidget(self.authenticate_group)
+        connection_type_layout.addWidget(self.connection_type_bridges_radio_group)
+        connection_type_layout.addWidget(self.connection_type_test_button)
 
         # Buttons
         self.save_button = QtWidgets.QPushButton(strings._('gui_settings_button_save', True))
@@ -356,8 +355,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
         right_col_layout = QtWidgets.QVBoxLayout()
         right_col_layout.addWidget(connection_type_radio_group)
-        right_col_layout.addWidget(connection_type_group)
-        right_col_layout.addWidget(self.connection_type_bridges_radio_group)
+        right_col_layout.addLayout(connection_type_layout)
         right_col_layout.addWidget(self.tor_status)
         right_col_layout.addStretch()
 

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -296,10 +296,6 @@ class SettingsDialog(QtWidgets.QDialog):
         self.authenticate_group = QtWidgets.QGroupBox(strings._("gui_settings_authenticate_label", True))
         self.authenticate_group.setLayout(authenticate_group_layout)
 
-        # Test tor settings button
-        self.connection_type_test_button = QtWidgets.QPushButton(strings._('gui_settings_connection_type_test_button', True))
-        self.connection_type_test_button.clicked.connect(self.test_tor_clicked)
-
         # Put the radios into their own group so they are exclusive
         connection_type_radio_group_layout = QtWidgets.QVBoxLayout()
         connection_type_radio_group_layout.addWidget(self.connection_type_bundled_radio)
@@ -316,6 +312,13 @@ class SettingsDialog(QtWidgets.QDialog):
         self.connection_type_bridges_radio_group.setLayout(connection_type_bridges_radio_group_layout)
         self.connection_type_bridges_radio_group.hide()
 
+        # Test tor settings button
+        self.connection_type_test_button = QtWidgets.QPushButton(strings._('gui_settings_connection_type_test_button', True))
+        self.connection_type_test_button.clicked.connect(self.test_tor_clicked)
+        connection_type_test_button_layout = QtWidgets.QHBoxLayout()
+        connection_type_test_button_layout.addWidget(self.connection_type_test_button)
+        connection_type_test_button_layout.addStretch()
+
         # Connection type layout
         connection_type_layout = QtWidgets.QVBoxLayout()
         connection_type_layout.addWidget(self.connection_type_control_port_extras)
@@ -323,7 +326,7 @@ class SettingsDialog(QtWidgets.QDialog):
         connection_type_layout.addWidget(self.connection_type_socks)
         connection_type_layout.addWidget(self.authenticate_group)
         connection_type_layout.addWidget(self.connection_type_bridges_radio_group)
-        connection_type_layout.addWidget(self.connection_type_test_button)
+        connection_type_layout.addLayout(connection_type_test_button_layout)
 
         # Buttons
         self.save_button = QtWidgets.QPushButton(strings._('gui_settings_button_save', True))


### PR DESCRIPTION
This changes the Settings dialog layout slightly so that "Test Tor Settings" button is below all of the Tor settings. I also made that button left-aligned instead of taking up the full width, and removed an unnecessary group box.

![screenshot_2018-04-22_17-23-51](https://user-images.githubusercontent.com/156128/39101728-11cf34d6-4652-11e8-9f88-e787dd487419.png)

Here's what it used to look like:

![screenshot_2018-04-22_17-24-20](https://user-images.githubusercontent.com/156128/39101729-13cf8056-4652-11e8-9b6b-4e32285f6e71.png)
