### PR TITLE
Fix some lingering attribute/module references that had not been updated to use their new names/paths

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -560,7 +560,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 self.primary_action.hide()
                 self.info_widget.hide()
                 self.status_bar.showMessage(strings._('gui_tor_connection_lost', True))
-                if self.systemTray.supportsMessages() and self.settings.get('systray_notifications'):
+                if self.systemTray.supportsMessages() and self.common.settings.get('systray_notifications'):
                     self.systemTray.showMessage(strings._('gui_tor_connection_lost', True), strings._('gui_tor_connection_error_settings', True))
 
         # scroll to the bottom of the dl progress bar log pane
@@ -585,7 +585,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
 
             elif event["type"] == self.web.REQUEST_DOWNLOAD:
                 self.downloads.no_downloads_label.hide()
-                self.downloads.add_download(event["data"]["id"], web.zip_filesize)
+                self.downloads.add_download(event["data"]["id"], self.web.zip_filesize)
                 self.new_download = True
                 self.downloads_in_progress += 1
                 self.update_downloads_in_progress(self.downloads_in_progress)

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -503,7 +503,7 @@ class SettingsDialog(QtWidgets.QDialog):
             self.tor_bridges_use_custom_textbox_options.hide()
             # Alert the user about meek's costliness if it looks like they're turning it on
             if not self.old_settings.get('tor_bridges_use_meek_lite_amazon'):
-                Alert(strings._('gui_settings_meek_lite_expensive_warning', True), QtWidgets.QMessageBox.Warning)
+                Alert(self.common, strings._('gui_settings_meek_lite_expensive_warning', True), QtWidgets.QMessageBox.Warning)
 
     def tor_bridges_use_meek_lite_azure_radio_toggled(self, checked):
         """
@@ -513,7 +513,7 @@ class SettingsDialog(QtWidgets.QDialog):
             self.tor_bridges_use_custom_textbox_options.hide()
             # Alert the user about meek's costliness if it looks like they're turning it on
             if not self.old_settings.get('tor_bridges_use_meek_lite_azure'):
-                Alert(strings._('gui_settings_meek_lite_expensive_warning', True), QtWidgets.QMessageBox.Warning)
+                Alert(self.common, strings._('gui_settings_meek_lite_expensive_warning', True), QtWidgets.QMessageBox.Warning)
 
     def tor_bridges_use_custom_radio_toggled(self, checked):
         """

--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -716,7 +716,7 @@ class SettingsDialog(QtWidgets.QDialog):
                     self.common.log('SettingsDialog', 'save_clicked', 'rebooting the Onion')
                     self.onion.cleanup()
 
-                    tor_con = TorConnectionDialog(self.qtapp, settings, self.onion)
+                    tor_con = TorConnectionDialog(self.common, self.qtapp, self.onion, settings)
                     tor_con.start()
 
                     self.common.log('SettingsDialog', 'save_clicked', 'Onion done rebooting, connected to Tor: {}'.format(self.onion.connected_to_tor))


### PR DESCRIPTION
When working on a Mac, I came across a couple of rogue cases where attributes or objects had not been updated to use their new location per the recent mega-changes.

These included the systray notification check (which crashed the app), the Tor Connection dialog (when changing settings invoked a Tor connection reboot via the SettingsDialog), and when a download was performed by an end user (crashed the app because it couldn't add the download properly)

Fixes #712 
Fixes #727 