### PR TITLE
Fix installation of static assets on MacOS and probably Windows too

### DIFF
--- a/install/pyinstaller.spec
+++ b/install/pyinstaller.spec
@@ -21,7 +21,9 @@ a = Analysis(
         ('../share/images/*', 'share/images'),
         ('../share/locale/*', 'share/locale'),
         ('../share/templates/*', 'share/templates'),
-        ('../share/static/*', 'share/static')
+        ('../share/static/css/*', 'share/static/css'),
+        ('../share/static/img/*', 'share/static/img'),
+        ('../share/static/js/*', 'share/static/js')
     ],
     hiddenimports=[],
     hookspath=[],


### PR DESCRIPTION
This is related to #688 which turned out to only be a partial fix (fixed Linux only). 

This fixes the same issue but for Mac OS, and probably Windows too.

Fixes #693