### PR TITLE
suggesting standard checks for *BSD systems

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -57,7 +57,7 @@ def get_platform():
     Returns the platform OnionShare is running on.
     """
     plat = platform.system()
-    if plat.endswith('BSD'):
+    if plat.endswith('BSD') or plat == 'DragonFly':
         plat = 'BSD'
     return plat
 

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -334,7 +334,7 @@ class Onion(object):
             # guessing the socket file name next
             if not found_tor:
                 try:
-                    if self.system == 'Linux' or self.system == 'BSD':
+                    if self.system == 'Linux' or platform.system().endswith('BSD'):
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())
                     elif self.system == 'Darwin':
                         socket_file_path = '/run/user/{}/Tor/control.socket'.format(os.geteuid())

--- a/onionshare_gui/__init__.py
+++ b/onionshare_gui/__init__.py
@@ -36,7 +36,7 @@ class Application(QtWidgets.QApplication):
     """
     def __init__(self):
         system = common.get_platform()
-        if system == 'Linux' or system == 'BSD':
+        if system == 'Linux' or platform.system().endswith('BSD'):
             self.setAttribute(QtCore.Qt.AA_X11InitThreads, True)
         QtWidgets.QApplication.__init__(self, sys.argv)
         self.installEventFilter(self)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ data_files=[
         (os.path.join(sys.prefix, 'share/onionshare/locale'), file_list('share/locale')),
         (os.path.join(sys.prefix, 'share/onionshare/html'), file_list('share/html')),
     ]
-if platform.system() != 'OpenBSD':
+if not platform.system().endswith('BSD'):
     data_files.append(('/usr/share/nautilus-python/extensions/', ['install/scripts/onionshare-nautilus.py']))
 
 setup(


### PR DESCRIPTION
Hi,

for some 'if' checks I noticed that we might use the ".endswith('BSD')" function in order to verify if a system's platform is a BSD system or not.

other particular checks still enforce only 'BSD' as platform, and I preferred to kept them as is; once particular case is https://github.com/torbsd/onionshare/blob/egypcio/onionshare/common.py#L57 

I hope this brings something good for OnionShare and later on we can port it to even more BSD systems without the need of extra checks. the OpenBSD package is already available, and the FreeBSD one is almost ready to land; https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=225539

if any other particular needs are required to this merge, please tell me. would be happy to help!

thank you for all your work and concern! KR,