### PR TITLE
[receiver-mode-gui] Improve styling of receive mode HTML

### DIFF
--- a/onionshare/web.py
+++ b/onionshare/web.py
@@ -331,7 +331,7 @@ class Web(object):
                 print(strings._('error_downloads_dir_not_writable').format(self.common.settings.get('downloads_dir')))
                 valid = False
             if not valid:
-                flash('Error uploading, please inform the OnionShare user')
+                flash('Error uploading, please inform the OnionShare user', 'error')
                 if self.common.settings.get('receive_public_mode'):
                     return redirect('/')
                 else:
@@ -390,10 +390,10 @@ class Web(object):
             # Note that flash strings are on English, and not translated, on purpose,
             # to avoid leaking the locale of the OnionShare user
             if len(filenames) == 0:
-                flash('No files uploaded')
+                flash('No files uploaded', 'info')
             else:
                 for filename in filenames:
-                    flash('Uploaded {}'.format(filename))
+                    flash('Sent {}'.format(filename), 'info')
 
             if self.common.settings.get('receive_public_mode'):
                 return redirect('/')

--- a/share/static/css/style.css
+++ b/share/static/css/style.css
@@ -142,3 +142,53 @@ ul.flashes li {
   margin: 0;
   padding: 10px;
 }
+
+li.error {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  color: #ffffff;
+  background-color: #c90c0c;
+  border: 0;
+  border-radius: 5px;
+  text-align: left;
+}
+
+li.info {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  color: #000000;
+  background-color: #a9e26c;
+  border: 0;
+  border-radius: 5px;
+  text-align: left;
+}
+
+.closed-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+}
+
+.closed {
+  text-align: center;
+}
+
+.closed img {
+  width: 120px;
+  height: 120px;
+}
+
+.closed .closed-header {
+  font-size: 30px;
+  font-weight: normal;
+  color: #666666;
+  margin: 0 0 10px 0;
+}
+
+.closed .closed-description {
+  color: #666666;
+  margin: 0 0 20px 0;
+}

--- a/share/templates/closed.html
+++ b/share/templates/closed.html
@@ -3,8 +3,20 @@
   <head>
       <title>OnionShare is closed</title>
       <link href="/static/img/favicon.ico" rel="icon" type="image/x-icon" />
+      <link href="/static/css/style.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
-    <p>Thank you for using OnionShare</p>
+      <header class="clearfix">
+          <img class="logo" src="/static/img/logo.png" title="OnionShare">
+          <h1>OnionShare</h1>
+      </header>
+
+      <div class="closed-wrapper">
+          <div class="closed">
+              <p><img class="logo" src="/static/img/logo_large.png" title="OnionShare"></p>
+              <p class="closed-header">Thank you for using OnionShare</p>
+              <p class="closed-description">You may now close this window.</p>
+	  </div>
+      </div>
   </body>
 </html>

--- a/share/templates/receive.html
+++ b/share/templates/receive.html
@@ -21,11 +21,11 @@
            <p><input type="file" name="file[]" multiple /></p>
            <p><input type="submit" class="button" value="Send Files" /></p>
            <div>
-             {% with messages = get_flashed_messages() %}
+             {% with messages = get_flashed_messages(with_categories=true) %}
                {% if messages %}
                  <ul class=flashes>
-                 {% for message in messages %}
-                   <li>{{ message }}</li>
+                 {% for category, message in messages %}
+		 <li class="{{ category }}">{{ message }}</li>
                  {% endfor %}
                  </ul>
                {% endif %}
@@ -36,7 +36,7 @@
     </div>
     {% if receive_allow_receiver_shutdown %}
     <form method="post" action="{{ close_action }}">
-      <input type="submit" class="close-button" value="I'm Finished Uploading" />
+      <input type="submit" class="close-button" value="I'm Finished Sending" />
     </form>
     {% endif %}
   </body>

--- a/share/templates/receive.html
+++ b/share/templates/receive.html
@@ -35,9 +35,13 @@
       </div>
     </div>
     {% if receive_allow_receiver_shutdown %}
-    <form method="post" action="{{ close_action }}">
-      <input type="submit" class="close-button" value="I'm Finished Sending" />
-    </form>
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <form method="post" action="{{ close_action }}">
+            <input type="submit" class="close-button" value="I'm Finished Sending" />
+          </form>
+        {% endif %}
+      {% endwith %}
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Factoring in some feedback from @b-meson in https://github.com/micahflee/onionshare/pull/695#issuecomment-390857247 - better styling of the flash() messages in receive mode.

I also styled the closed.html page to be a lot more pleasant.

I also changed references to 'Uploading' to 'Sending', to keep the language consistent. This was because I nearly clicked 'I'm finished Uploading' after I selected a file, instead of Send, having momentarily taken it to mean 'These are all the files I'm intending to upload'. 

Finally - and maybe this is a bit more contentious - I think that 'I'm Finished Sending' should actually only appear after a flash() message has appeared (e.g after a POST request has then loaded the page, indicating something either has already sent (or failed to send)). It shouldn't appear on initial page load because the user hasn't 'finished' doing anything at all. 

This will further reduce the risk of a user accidentally clicking that button before they've actually clicked 'Send', and I think is better UX.

The only side-effect of that change is that the user can't 'change their mind' and decide to close the server before ever attempting to send anything. But the receiver can still always choose to Stop the receive mode themselves, as well as can choose whether the sender has that ability or not at all in the first place.
