### PR TITLE
Add explicit dependency on rpm-build in the BUILD.md. Add a link to community-provided OpenSuSE instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,7 @@ Install the needed dependencies:
 
 For Debian-like distros: `apt install -y build-essential fakeroot python3-all python3-stdeb dh-python  python3-flask python3-stem python3-pyqt5 python-nautilus python3-pytest tor obfs4proxy`
 
-For Fedora-like distros: `dnf install -y rpm-build python3-flask python3-stem python3-qt5 python3-pytest nautilus-python tor obfs4`
+For Fedora-like distros: `dnf install -y rpm-build python3-flask python3-stem python3-qt5 python3-pytest nautilus-python tor obfs4 rpm-build`
 
 After that you can try both the CLI and the GUI version of OnionShare:
 
@@ -27,6 +27,8 @@ You can also build OnionShare packages to install:
 Create a .deb on Debian-like distros: `./install/build_deb.sh`
 
 Create a .rpm on Fedora-like distros: `./install/build_rpm.sh`
+
+For OpenSuSE: There are instructions for building [in the wiki](https://github.com/micahflee/onionshare/wiki/Linux-Distribution-Support#opensuse-leap-150).
 
 For ArchLinux: There is a PKBUILD available [here](https://aur.archlinux.org/packages/onionshare/) that can be used to install OnionShare.
 


### PR DESCRIPTION
Fixes #728