### PR TITLE
Fix the passing of the latest version returned to the UI if it is an invalid version

### DIFF
--- a/onionshare_gui/settings_dialog.py
+++ b/onionshare_gui/settings_dialog.py
@@ -658,8 +658,8 @@ class SettingsDialog(QtWidgets.QDialog):
             Alert(self.common, strings._('update_error_check_error', True), QtWidgets.QMessageBox.Warning)
             close_forced_update_thread()
 
-        def update_invalid_version():
-            Alert(self.common, strings._('update_error_invalid_latest_version', True).format(e.latest_version), QtWidgets.QMessageBox.Warning)
+        def update_invalid_version(latest_version):
+            Alert(self.common, strings._('update_error_invalid_latest_version', True).format(latest_version), QtWidgets.QMessageBox.Warning)
             close_forced_update_thread()
 
         forced_update_thread = UpdateThread(self.common, self.onion, self.config, force=True)

--- a/onionshare_gui/update_checker.py
+++ b/onionshare_gui/update_checker.py
@@ -53,7 +53,7 @@ class UpdateChecker(QtCore.QObject):
     update_available = QtCore.pyqtSignal(str, str, str)
     update_not_available = QtCore.pyqtSignal()
     update_error = QtCore.pyqtSignal()
-    update_invalid_version = QtCore.pyqtSignal()
+    update_invalid_version = QtCore.pyqtSignal(str)
 
     def __init__(self, common, onion, config=False):
         super(UpdateChecker, self).__init__()
@@ -136,7 +136,7 @@ class UpdateChecker(QtCore.QObject):
             # This regex is: 1-3 dot-separated numeric components
             version_re = r"^(\d+\.)?(\d+\.)?(\d+)$"
             if not re.match(version_re, latest_version):
-                self.update_invalid_version.emit()
+                self.update_invalid_version.emit(latest_version)
                 raise UpdateCheckerInvalidLatestVersion(latest_version)
 
             # Update the last checked timestamp (dropping the seconds and milliseconds)
@@ -160,7 +160,7 @@ class UpdateThread(QtCore.QThread):
     update_available = QtCore.pyqtSignal(str, str, str)
     update_not_available = QtCore.pyqtSignal()
     update_error = QtCore.pyqtSignal()
-    update_invalid_version = QtCore.pyqtSignal()
+    update_invalid_version = QtCore.pyqtSignal(str)
 
     def __init__(self, common, onion, config=False, force=False):
         super(UpdateThread, self).__init__()
@@ -203,7 +203,7 @@ class UpdateThread(QtCore.QThread):
         self.active = False
         self.update_error.emit()
 
-    def _update_invalid_version(self):
+    def _update_invalid_version(self, latest_version):
         self.common.log('UpdateThread', '_update_invalid_version')
         self.active = False
-        self.update_invalid_version.emit()
+        self.update_invalid_version.emit(latest_version)


### PR DESCRIPTION
I found an obscure bug related to when/if the Update Check returned an invalid version from the onion service.

(how I found it: I had added so many security headers to the vhost in the new infra, that I caused the http_response recv(1024) to be not returning the actual page content (`\r\r\r1.3.1\n`), because there were so many headers sent in the response that it didn't fit in the size of the response :rofl: . That's also now been fixed...)

An invalid version received currently crashes the app with this stack trace:

```
[Aug 30 2018 09:39:16] UpdateChecker.check: latest OnionShare version: i
[Aug 30 2018 09:39:16] UpdateThread.run: i
[Aug 30 2018 09:39:16] UpdateThread._update_invalid_version
Traceback (most recent call last):
  File "/Users/miguel/git/onionshare/onionshare_gui/settings_dialog.py", line 748, in update_invalid_version
    Alert(self.common, strings._('update_error_invalid_latest_version', True).format(e.latest_version), QtWidgets.QMessageBox.Warning)
NameError: name 'e' is not defined
Abort trap: 6
```

This patch fixes the passing of latest_version back to the emitted signal for displaying as intended.