### PR TITLE
Pass self to help_clicked function in systray, so we can use self.common

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -277,7 +277,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
         self.settingsAction = menu.addAction(strings._('gui_settings_window_title', True))
         self.settingsAction.triggered.connect(self.open_settings)
         self.helpAction = menu.addAction(strings._('gui_settings_button_help', True))
-        self.helpAction.triggered.connect(SettingsDialog.help_clicked)
+        self.helpAction.triggered.connect(lambda: SettingsDialog.help_clicked(self))
         self.exitAction = menu.addAction(strings._('systray_menu_exit', True))
         self.exitAction.triggered.connect(self.close)
 


### PR DESCRIPTION
Fixes #702 

(Yes, it looks weird, but apparently it's the right way to send an argument to a function in a signal slot https://stackoverflow.com/questions/940555/pyqt-sending-parameter-to-slot-when-connecting-to-a-signal)

An even simpler fix might be to just don't bother logging the 'help clicked' event at all, I leave it up to you