### PR TITLE
Don't show the Flask shutdown slug route in the status bar as if it w…

### DIFF
--- a/onionshare_gui/onionshare_gui.py
+++ b/onionshare_gui/onionshare_gui.py
@@ -401,7 +401,7 @@ class OnionShareGui(QtWidgets.QMainWindow):
                 Alert(self.common, strings._('error_downloads_dir_not_writable').format(self.common.settings.get('downloads_dir')))
 
             if event["type"] == Web.REQUEST_OTHER:
-                if event["path"] != '/favicon.ico':
+                if event["path"] != '/favicon.ico' and event["path"] != "{}/shutdown".format(mode.web.shutdown_slug):
                     self.status_bar.showMessage('[#{0:d}] {1:s}: {2:s}'.format(mode.web.error404_count, strings._('other_page_loaded', True), event["path"]))
 
         mode.timer_callback()


### PR DESCRIPTION
…ere an unexpected 404 route

After our recent changes re: public mode and routes, the Flash shutdown_slug path was appearing in the system tray on close of the share, with a counter, as if it were an unexpected, invalid page load.

![onionshare_shutdown_slug_load_message](https://user-images.githubusercontent.com/99173/45593181-6fc8ec00-b9c3-11e8-87f1-a1199c5d2848.png)

This change filters out that route so it doesn't appear.

