### PR TITLE
Close the upload widget on reset so that it properly disappears from the Uploads window

### DIFF
--- a/onionshare_gui/receive_mode/uploads.py
+++ b/onionshare_gui/receive_mode/uploads.py
@@ -290,6 +290,7 @@ class Uploads(QtWidgets.QScrollArea):
         """
         self.common.log('Uploads', 'reset')
         for upload in self.uploads.values():
+            upload.close()
             self.uploads_layout.removeWidget(upload)
         self.uploads = {}
 


### PR DESCRIPTION
This fixes "Related, if I start the server in receive mode, start uploading large files, then stop the server before they've uploaded, the upload history window still shows the in-progress upload." in #748 

the removeWidget() beneath this change doesn't appear to actually do anything, but I left it in, in case it *does* and I just couldn't tell. But only close() on the upload widget seems to actually remove it.

I have a feeling this also fixes the mysterious  #732 which I did reproduce yesterday on Linux (but wasn't sure how I did then, either). I suspect it's when the 'No uploads yet' label overlaps the uploads of a previous share, when they should've been removed.