### PR TITLE
Fix the auto-scrolling to bottom of Download and Upload windows

### DIFF
--- a/onionshare_gui/receive_mode/uploads.py
+++ b/onionshare_gui/receive_mode/uploads.py
@@ -227,6 +227,7 @@ class Uploads(QtWidgets.QScrollArea):
         self.setWindowIcon(QtGui.QIcon(common.get_resource_path('images/logo.png')))
         self.setWindowFlags(QtCore.Qt.Sheet | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.CustomizeWindowHint)
         self.vbar = self.verticalScrollBar()
+        self.vbar.rangeChanged.connect(self.resizeScroll)
 
         uploads_label = QtWidgets.QLabel(strings._('gui_uploads', True))
         uploads_label.setStyleSheet(self.common.css['downloads_uploads_label'])
@@ -243,6 +244,12 @@ class Uploads(QtWidgets.QScrollArea):
         widget.setLayout(layout)
         self.setWidget(widget)
 
+    def resizeScroll(self, minimum, maximum):
+        """
+        Scroll to the bottom of the window when the range changes.
+        """
+        self.vbar.setValue(maximum)
+
     def add(self, upload_id, content_length):
         """
         Add a new upload.
@@ -255,9 +262,6 @@ class Uploads(QtWidgets.QScrollArea):
         upload = Upload(self.common, upload_id, content_length)
         self.uploads[upload_id] = upload
         self.uploads_layout.addWidget(upload)
-
-        # Scroll to the bottom
-        self.vbar.setValue(self.vbar.maximum())
 
     def update(self, upload_id, progress):
         """

--- a/onionshare_gui/share_mode/downloads.py
+++ b/onionshare_gui/share_mode/downloads.py
@@ -97,6 +97,7 @@ class Downloads(QtWidgets.QScrollArea):
         self.setWindowIcon(QtGui.QIcon(common.get_resource_path('images/logo.png')))
         self.setWindowFlags(QtCore.Qt.Sheet | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.CustomizeWindowHint)
         self.vbar = self.verticalScrollBar()
+        self.vbar.rangeChanged.connect(self.resizeScroll)
 
         downloads_label = QtWidgets.QLabel(strings._('gui_downloads', True))
         downloads_label.setStyleSheet(self.common.css['downloads_uploads_label'])
@@ -113,6 +114,12 @@ class Downloads(QtWidgets.QScrollArea):
         widget.setLayout(layout)
         self.setWidget(widget)
 
+    def resizeScroll(self, minimum, maximum):
+        """
+        Scroll to the bottom of the window when the range changes.
+        """
+        self.vbar.setValue(maximum)
+
     def add(self, download_id, total_bytes):
         """
         Add a new download progress bar.
@@ -124,9 +131,6 @@ class Downloads(QtWidgets.QScrollArea):
         download = Download(self.common, download_id, total_bytes)
         self.downloads[download_id] = download
         self.downloads_layout.addWidget(download.progress_bar)
-
-        # Scroll to the bottom
-        self.vbar.setValue(self.vbar.maximum())
 
     def update(self, download_id, downloaded_bytes):
         """


### PR DESCRIPTION
Fixes 'More thoroughly test the toggle button for Uploads/Downloads, making sure it actually scrolls to the bottom at the appropriate times, etc.' of #748 

The old method didn't seem to quite work - it *nearly* scrolled all the way to the bottom, but not quite.

I found another way from https://stackoverflow.com/questions/25964026/pyside-auto-scroll-down-in-qscrollarea which definitely works on Linux.