### PR TITLE
#704 wrap the upload filename label if too long

### DIFF
--- a/onionshare_gui/receive_mode/uploads.py
+++ b/onionshare_gui/receive_mode/uploads.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
 import subprocess
+import textwrap
 from datetime import datetime
 from PyQt5 import QtCore, QtWidgets, QtGui
 
@@ -305,10 +306,7 @@ class Uploads(QtWidgets.QScrollArea):
        try:
            for upload in self.uploads.values():
                for item in upload.files.values():
-                   if item.filename_label_width > width:
-                       item.filename_label.setText(item.filename[:25] + '[...]')
-                       item.adjustSize()
-                   if width > item.filename_label_width:
-                       item.filename_label.setText(item.filename)
+                   item.filename_label.setText(textwrap.fill(item.filename, 30))
+                   item.adjustSize()
        except:
            pass


### PR DESCRIPTION
Let me know if this fixes #704 properly now?

If the filename label is small enough, textwrap simply seems to do nothing, which is nice. If it's too long, it wraps it.