### PR TITLE
Add 'clear history' button to downloads and uploads windows

### DIFF
--- a/onionshare_gui/receive_mode/uploads.py
+++ b/onionshare_gui/receive_mode/uploads.py
@@ -232,6 +232,10 @@ class Uploads(QtWidgets.QScrollArea):
         uploads_label = QtWidgets.QLabel(strings._('gui_uploads', True))
         uploads_label.setStyleSheet(self.common.css['downloads_uploads_label'])
         self.no_uploads_label = QtWidgets.QLabel(strings._('gui_no_uploads', True))
+        self.clear_history_button = QtWidgets.QPushButton(strings._('gui_clear_history', True))
+        self.clear_history_button.clicked.connect(self.reset)
+        self.clear_history_button.hide()
+
 
         self.uploads_layout = QtWidgets.QVBoxLayout()
 
@@ -239,6 +243,7 @@ class Uploads(QtWidgets.QScrollArea):
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(uploads_label)
         layout.addWidget(self.no_uploads_label)
+        layout.addWidget(self.clear_history_button)
         layout.addLayout(self.uploads_layout)
         layout.addStretch()
         widget.setLayout(layout)
@@ -257,6 +262,8 @@ class Uploads(QtWidgets.QScrollArea):
         self.common.log('Uploads', 'add', 'upload_id: {}, content_length: {}'.format(upload_id, content_length))
         # Hide the no_uploads_label
         self.no_uploads_label.hide()
+        # Show the clear_history_button
+        self.clear_history_button.show()
 
         # Add it to the list
         upload = Upload(self.common, upload_id, content_length)
@@ -299,6 +306,7 @@ class Uploads(QtWidgets.QScrollArea):
         self.uploads = {}
 
         self.no_uploads_label.show()
+        self.clear_history_button.hide()
         self.resize(self.sizeHint())
 
     def resizeEvent(self, event):

--- a/onionshare_gui/share_mode/downloads.py
+++ b/onionshare_gui/share_mode/downloads.py
@@ -102,6 +102,9 @@ class Downloads(QtWidgets.QScrollArea):
         downloads_label = QtWidgets.QLabel(strings._('gui_downloads', True))
         downloads_label.setStyleSheet(self.common.css['downloads_uploads_label'])
         self.no_downloads_label = QtWidgets.QLabel(strings._('gui_no_downloads', True))
+        self.clear_history_button = QtWidgets.QPushButton(strings._('gui_clear_history', True))
+        self.clear_history_button.clicked.connect(self.reset)
+        self.clear_history_button.hide()
 
         self.downloads_layout = QtWidgets.QVBoxLayout()
 
@@ -109,6 +112,7 @@ class Downloads(QtWidgets.QScrollArea):
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(downloads_label)
         layout.addWidget(self.no_downloads_label)
+        layout.addWidget(self.clear_history_button)
         layout.addLayout(self.downloads_layout)
         layout.addStretch()
         widget.setLayout(layout)
@@ -126,6 +130,8 @@ class Downloads(QtWidgets.QScrollArea):
         """
         # Hide the no_downloads_label
         self.no_downloads_label.hide()
+        # Show the clear_history_button
+        self.clear_history_button.show()
 
         # Add it to the list
         download = Download(self.common, download_id, total_bytes)
@@ -154,4 +160,5 @@ class Downloads(QtWidgets.QScrollArea):
         self.downloads = {}
 
         self.no_downloads_label.show()
+        self.clear_history_button.hide()
         self.resize(self.sizeHint())

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -181,6 +181,7 @@
     "gui_uploads": "Upload History",
     "gui_uploads_window_tooltip": "Show/hide uploads",
     "gui_no_uploads": "No uploads yet.",
+    "gui_clear_history": "Clear history",
     "gui_upload_in_progress": "Upload Started {}",
     "gui_upload_finished_range": "Uploaded {} to {}",
     "gui_upload_finished": "Uploaded {}",


### PR DESCRIPTION
This PR adds a 'clear history' button to both the Downloads and Uploads windows.

It only appears once there's *been* an upload or download. And it disappears again when cleared.

I am leaving the 'counters' in place, as I feel that's maybe useful information to retain, in other words it only clears the widgets but not the counters to 'tidy up' the uploads/downloads windows. This might be contentious, I leave it up to you if you want to change it.