### PR TITLE
Start the WebThread earlier than the Onion service. This gives it a c…

### DIFF
--- a/onionshare_gui/threads.py
+++ b/onionshare_gui/threads.py
@@ -41,14 +41,6 @@ class OnionThread(QtCore.QThread):
     def run(self):
         self.mode.common.log('OnionThread', 'run')
 
-        try:
-            self.mode.app.start_onion_service()
-            self.success.emit()
-
-        except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorTimeout, OSError) as e:
-            self.error.emit(e.args[0])
-            return
-
         self.mode.app.stay_open = not self.mode.common.settings.get('close_after_first_download')
 
         # start onionshare http service in new thread
@@ -57,6 +49,14 @@ class OnionThread(QtCore.QThread):
 
         # wait for modules in thread to load, preventing a thread-related cx_Freeze crash
         time.sleep(0.2)
+
+        try:
+            self.mode.app.start_onion_service()
+            self.success.emit()
+
+        except (TorTooOld, TorErrorInvalidSetting, TorErrorAutomatic, TorErrorSocketPort, TorErrorSocketFile, TorErrorMissingPassword, TorErrorUnreadableCookieFile, TorErrorAuthError, TorErrorProtocolError, BundledTorTimeout, OSError) as e:
+            self.error.emit(e.args[0])
+            return
 
 
 class WebThread(QtCore.QThread):


### PR DESCRIPTION
…hance to generate its slug before the Onion Service finishes starting up, which can otherwise lead to a crash

Fixes #764 for me. I suspect the v3 onions can be so fast at starting up, that this issue was introduced by that fact - the Onion service can start up faster than the WebThread can fire its run() to generate the slug.

We might also need a more graceful try/catch/raise Exception in `ServerStatus.get_url()`, which is where the crash occurred in #764 (presumably because self.web.slug was None due to not having been built yet). Wasn't sure the best way to add that.