### PR TITLE
Choose a port *before* starting the web service

### DIFF
--- a/onionshare_gui/threads.py
+++ b/onionshare_gui/threads.py
@@ -73,4 +73,5 @@ class WebThread(QtCore.QThread):
 
     def run(self):
         self.mode.common.log('WebThread', 'run')
+        self.mode.app.choose_port()
         self.mode.web.start(self.mode.app.port, self.mode.app.stay_open, self.mode.common.settings.get('slug'))


### PR DESCRIPTION
Oops, it looks like #768 introduced a new bug. The web port was getting chosen in the `start_onion_service` function, which didn't get executed until after flask started, so the web app was also starting on port 5000.

This fixes it.