### PR TITLE
New UI to always show history

### DIFF
--- a/onionshare_gui/mode.py
+++ b/onionshare_gui/mode.py
@@ -78,7 +78,11 @@ class Mode(QtWidgets.QWidget):
         # Layout
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.addWidget(self.primary_action)
-        self.setLayout(self.layout)
+
+        self.horizontal_layout_wrapper = QtWidgets.QHBoxLayout()
+        self.horizontal_layout_wrapper.addLayout(self.layout)
+
+        self.setLayout(self.horizontal_layout_wrapper)
 
     def init(self):
         """

--- a/onionshare_gui/mode.py
+++ b/onionshare_gui/mode.py
@@ -78,6 +78,10 @@ class Mode(QtWidgets.QWidget):
         # Layout
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.addWidget(self.primary_action)
+        # Hack to allow a minimum width on self.layout
+        min_width_widget = QtWidgets.QWidget()
+        min_width_widget.setMinimumWidth(450)
+        self.layout.addWidget(min_width_widget)
 
         self.horizontal_layout_wrapper = QtWidgets.QHBoxLayout()
         self.horizontal_layout_wrapper.addLayout(self.layout)

--- a/onionshare_gui/receive_mode/__init__.py
+++ b/onionshare_gui/receive_mode/__init__.py
@@ -46,7 +46,7 @@ class ReceiveMode(Mode):
         self.server_status.web = self.web
         self.server_status.update()
 
-        # Downloads
+        # Uploads
         self.uploads = Uploads(self.common)
         self.uploads_in_progress = 0
         self.uploads_completed = 0
@@ -86,6 +86,7 @@ class ReceiveMode(Mode):
         # Layout
         self.layout.insertWidget(0, self.receive_info)
         self.layout.insertWidget(0, self.info_widget)
+        self.horizontal_layout_wrapper.addWidget(self.uploads)
 
     def get_stop_server_shutdown_timeout_text(self):
         """

--- a/onionshare_gui/receive_mode/uploads.py
+++ b/onionshare_gui/receive_mode/uploads.py
@@ -222,7 +222,6 @@ class Uploads(QtWidgets.QScrollArea):
 
         self.setWindowTitle(strings._('gui_uploads', True))
         self.setWidgetResizable(True)
-        self.setMaximumHeight(600)
         self.setMinimumHeight(150)
         self.setMinimumWidth(350)
         self.setWindowIcon(QtGui.QIcon(common.get_resource_path('images/logo.png')))

--- a/onionshare_gui/share_mode/__init__.py
+++ b/onionshare_gui/share_mode/__init__.py
@@ -116,6 +116,7 @@ class ShareMode(Mode):
         # Layout
         self.layout.insertLayout(0, self.file_selection)
         self.layout.insertWidget(0, self.info_widget)
+        self.horizontal_layout_wrapper.addWidget(self.downloads)
 
         # Always start with focus on file selection
         self.file_selection.setFocus()

--- a/onionshare_gui/share_mode/downloads.py
+++ b/onionshare_gui/share_mode/downloads.py
@@ -91,7 +91,6 @@ class Downloads(QtWidgets.QScrollArea):
 
         self.setWindowTitle(strings._('gui_downloads', True))
         self.setWidgetResizable(True)
-        self.setMaximumHeight(600)
         self.setMinimumHeight(150)
         self.setMinimumWidth(350)
         self.setWindowIcon(QtGui.QIcon(common.get_resource_path('images/logo.png')))


### PR DESCRIPTION
So I've been thinking about the OnionShare UI, and also about features I want in the future (specifically, multitasking -- the ability to run multiple share or receive modes (or any mode in the future) in different "tabs"), and part of that included making this change. And the more I think about it, the more I like it... It even works when you maximize the window, so it'll look good on tiling window managers.

What do you think?

Some screenshots:

![screenshot_2018-09-19_19-06-21](https://user-images.githubusercontent.com/156128/45791712-b460bb80-bc3f-11e8-8644-46a5e1cb9508.png)
![screenshot_2018-09-19_19-07-32](https://user-images.githubusercontent.com/156128/45791713-b4f95200-bc3f-11e8-9933-8a66d990bb09.png)
![screenshot_2018-09-19_19-08-25](https://user-images.githubusercontent.com/156128/45791714-b4f95200-bc3f-11e8-8797-8ca577a48316.png)
