### PR TITLE
Bump Tor to 0.3.4.8

### DIFF
--- a/install/get-tor-osx.py
+++ b/install/get-tor-osx.py
@@ -35,9 +35,9 @@ import subprocess
 import requests
 
 def main():
-    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/8.0/TorBrowser-8.0-osx64_en-US.dmg'
-    dmg_filename = 'TorBrowser-8.0-osx64_en-US.dmg'
-    expected_dmg_sha256 = '15603ae7b3a1942863c98acc92f509e4409db48fe22c9acae6b15c9cb9bf3088'
+    dmg_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/8.0.1/TorBrowser-8.0.1-osx64_en-US.dmg'
+    dmg_filename = 'TorBrowser-8.0.1-osx64_en-US.dmg'
+    expected_dmg_sha256 = 'fb1be2a0f850a65bae38747c3abbf9061742c5d7799e1693405078aaf38d2b08'
 
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))

--- a/install/get-tor-windows.py
+++ b/install/get-tor-windows.py
@@ -33,9 +33,9 @@ import subprocess
 import requests
 
 def main():
-    exe_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/8.0/torbrowser-install-8.0_en-US.exe'
-    exe_filename = 'torbrowser-install-8.0_en-US.exe'
-    expected_exe_sha256 = '0682b44eff5877dfc2fe2fdd5b46e678d47adad86d564e7cb6654c5f60eb1ed2'
+    exe_url = 'https://archive.torproject.org/tor-package-archive/torbrowser/8.0.1/torbrowser-install-8.0.1_en-US.exe'
+    exe_filename = 'torbrowser-install-8.0.1_en-US.exe'
+    expected_exe_sha256 = 'bdf81d4282b991a6425c213c7b03b3f5c1f17bb02986b7fe9a1891e577e51639'
     # Build paths
     root_path = os.path.dirname(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))
     working_path = os.path.join(os.path.join(root_path, 'build'), 'tor')


### PR DESCRIPTION
Tor Browser 8.0.1 is shipping the first stable Tor in the 0.3.4 series (0.3.4.8) which solves an annoying crash bug on older macOS systems (10.9.x).
https://blog.torproject.org/new-release-tor-browser-801