### PR TITLE
Analyse the right file size to determine if the download has finished…

### DIFF
--- a/onionshare/web/share_mode.py
+++ b/onionshare/web/share_mode.py
@@ -71,9 +71,9 @@ class ShareModeWeb(object):
 
             # If download is allowed to continue, serve download page
             if self.should_use_gzip():
-                filesize = self.gzip_filesize
+                self.filesize = self.gzip_filesize
             else:
-                filesize = self.download_filesize
+                self.filesize = self.download_filesize
 
             if self.web.slug:
                 r = make_response(render_template(
@@ -81,7 +81,7 @@ class ShareModeWeb(object):
                     slug=self.web.slug,
                     file_info=self.file_info,
                     filename=os.path.basename(self.download_filename),
-                    filesize=filesize,
+                    filesize=self.filesize,
                     filesize_human=self.common.human_readable_filesize(self.download_filesize),
                     is_zipped=self.is_zipped))
             else:
@@ -90,7 +90,7 @@ class ShareModeWeb(object):
                     'send.html',
                     file_info=self.file_info,
                     filename=os.path.basename(self.download_filename),
-                    filesize=filesize,
+                    filesize=self.filesize,
                     filesize_human=self.common.human_readable_filesize(self.download_filesize),
                     is_zipped=self.is_zipped))
             return self.web.add_security_headers(r)
@@ -132,10 +132,10 @@ class ShareModeWeb(object):
             use_gzip = self.should_use_gzip()
             if use_gzip:
                 file_to_download = self.gzip_filename
-                filesize = self.gzip_filesize
+                self.filesize = self.gzip_filesize
             else:
                 file_to_download = self.download_filename
-                filesize = self.download_filesize
+                self.filesize = self.download_filesize
 
             # Tell GUI the download started
             self.web.add_request(self.web.REQUEST_STARTED, path, {
@@ -175,7 +175,7 @@ class ShareModeWeb(object):
 
                             # tell GUI the progress
                             downloaded_bytes = fp.tell()
-                            percent = (1.0 * downloaded_bytes / filesize) * 100
+                            percent = (1.0 * downloaded_bytes / self.filesize) * 100
 
                             # only output to stdout if running onionshare in CLI mode, or if using Linux (#203, #304)
                             if not self.web.is_gui or self.common.platform == 'Linux' or self.common.platform == 'BSD':
@@ -221,7 +221,7 @@ class ShareModeWeb(object):
             r = Response(generate())
             if use_gzip:
                 r.headers.set('Content-Encoding', 'gzip')
-            r.headers.set('Content-Length', filesize)
+            r.headers.set('Content-Length', self.filesize)
             r.headers.set('Content-Disposition', 'attachment', filename=basename)
             r = self.web.add_security_headers(r)
             # guess content type

--- a/onionshare_gui/share_mode/__init__.py
+++ b/onionshare_gui/share_mode/__init__.py
@@ -246,7 +246,7 @@ class ShareMode(Mode):
         self.downloads.update(event["data"]["id"], event["data"]["bytes"])
 
         # Is the download complete?
-        if event["data"]["bytes"] == self.web.share_mode.download_filesize:
+        if event["data"]["bytes"] == self.web.share_mode.filesize:
             self.system_tray.showMessage(strings._('systray_download_completed_title', True), strings._('systray_download_completed_message', True))
 
             # Update the total 'completed downloads' info


### PR DESCRIPTION
… in the UI (in order to decide whether to stop server yet)

Fixes #787 I think - this was a regression related to gzip compression: the conditional in the UI that decides whether to fire `stop_server()` was based on the wrong file size.