### PR TITLE
Fix call to Alert() when an autostop timer has run out before starting the share

### DIFF
--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -269,7 +269,7 @@ class ServerStatus(QtWidgets.QWidget):
                     self.timeout = self.shutdown_timeout.dateTime().toPyDateTime().replace(second=0, microsecond=0)
                 # If the timeout has actually passed already before the user hit Start, refuse to start the server.
                 if QtCore.QDateTime.currentDateTime().toPyDateTime() > self.timeout:
-                    Alert(self.common, strings._('gui_server_timeout_expired', QtWidgets.QMessageBox.Warning))
+                    Alert(self.common, strings._('gui_server_timeout_expired'), QtWidgets.QMessageBox.Warning)
                 else:
                     self.start_server()
             else:


### PR DESCRIPTION
A bug found via writing GUI unit tests :heart_eyes: 

```
CALL ERROR: Qt exceptions in virtual methods:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/user/git/onionshare/onionshare_gui/server_status.py", line 272, in server_button_clicked
    Alert(self.common, strings._('gui_server_timeout_expired', QtWidgets.QMessageBox.Warning))
TypeError: translated() takes 1 positional argument but 2 were given
```

A test for this will be added in #805 