### PR TITLE
Minor locale update to be able to merge more weblate translations

### DIFF
--- a/onionshare/strings.py
+++ b/onionshare/strings.py
@@ -45,7 +45,7 @@ def load_strings(common):
     current_locale = common.settings.get('locale')
     strings = {}
     for s in translations[default_locale]:
-        if s in translations[current_locale]:
+        if s in translations[current_locale] and translations[current_locale][s] != "":
             strings[s] = translations[current_locale][s]
         else:
             strings[s] = translations[default_locale][s]


### PR DESCRIPTION
If a locale file includes a blank string, this PR makes it fallback to English instead of using the blank string. This will let us merge unfinished weblate translations, which include a bunch of blank strings rather than just not including those strings.

Just FYI @mig5 @emmapeel2. This is a pretty trivial patch which I've already tested, so I'm going to go ahead and merge it myself.