### PR TITLE
Fix building debian packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
   test-3.5: &test-template
     docker:
       - image: circleci/python:3.5.6
-      
+
     working_directory: ~/repo
 
     steps:
@@ -33,7 +33,7 @@ jobs:
       # run tests!
       - run:
           name: run flake tests
-          command: | 
+          command: |
             # stop the build if there are Python syntax errors or undefined names
             flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
             # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            xvfb-run pytest --cov=onionshare --cov=onionshare_gui --cov-report=term-missing -vvv tests/
+            xvfb-run pytest --cov=onionshare --cov=onionshare_gui --cov-report=term-missing -vvv tests/ --rungui
 
   test-3.6:
     <<: *test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            xvfb-run pytest --cov=onionshare --cov=onionshare_gui --cov-report=term-missing -vvv tests/ --rungui
+            xvfb-run pytest --rungui --cov=onionshare --cov=onionshare_gui --cov-report=term-missing -vvv tests/
 
   test-3.6:
     <<: *test-template

--- a/BUILD.md
+++ b/BUILD.md
@@ -155,10 +155,16 @@ Then you can run `pytest` against the `tests/` directory.
 pytest tests/
 ```
 
+You can run GUI tests like this:
+
+```sh
+pytest --rungui tests/
+```
+
 If you would like to also run the GUI unit tests in 'tor' mode, start Tor Browser in the background, then run:
 
 ```sh
-pytest --runtor tests/
+pytest --rungui --runtor tests/
 ```
 
 Keep in mind that the Tor tests take a lot longer to run than local mode, but they are also more comprehensive.
@@ -166,5 +172,5 @@ Keep in mind that the Tor tests take a lot longer to run than local mode, but th
 You can also choose to wrap the tests in `xvfb-run` so that a ton of OnionShare windows don't pop up on your desktop (you may need to install the `xorg-x11-server-Xvfb` package), like this:
 
 ```sh
-xvfb-run pytest tests/
+xvfb-run pytest --rungui tests/
 ```

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package3: onionshare
-Depends3: python3-flask, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python-nautilus, tor, obfs4proxy
-Build-Depends: python3-pytest, python3-flask, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python-nautilus, tor, obfs4proxy
+Depends3: python3, python3-flask, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python-nautilus, tor, obfs4proxy
+Build-Depends: python3, python3-pytest, python3-flask, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python-nautilus, tor, obfs4proxy
 Suite: bionic
 X-Python3-Version: >= 3.5.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,27 @@ from onionshare import common, web, settings, strings
 
 def pytest_addoption(parser):
     parser.addoption(
+        "--rungui", action="store_true", default=False, help="run GUI tests"
+    )
+    parser.addoption(
         "--runtor", action="store_true", default=False, help="run tor tests"
     )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runtor"):
+    if not config.getoption("--runtor"):
         # --runtor given in cli: do not skip tor tests
-        return
-    skip_tor = pytest.mark.skip(reason="need --runtor option to run")
-    for item in items:
-        if "tor" in item.keywords:
-            item.add_marker(skip_tor)
+        skip_tor = pytest.mark.skip(reason="need --runtor option to run")
+        for item in items:
+            if "tor" in item.keywords:
+                item.add_marker(skip_tor)
+
+    if not config.getoption('--rungui'):
+        # --rungui given in cli: do not skip GUI tests
+        skip_gui = pytest.mark.skip(reason="need --rungui option to run")
+        for item in items:
+            if "gui" in item.keywords:
+                item.add_marker(skip_gui)
 
 
 @pytest.fixture

--- a/tests/local_onionshare_404_public_mode_skips_ratelimit_test.py
+++ b/tests/local_onionshare_404_public_mode_skips_ratelimit_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -16,6 +17,7 @@ class Local404PublicModeRateLimitTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(True, True)

--- a/tests/local_onionshare_404_triggers_ratelimit_test.py
+++ b/tests/local_onionshare_404_triggers_ratelimit_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -15,6 +16,7 @@ class Local404RateLimitTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(False, True)

--- a/tests/local_onionshare_quitting_during_share_prompts_warning_test.py
+++ b/tests/local_onionshare_quitting_during_share_prompts_warning_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 from PyQt5 import QtCore, QtTest
 
@@ -16,6 +17,7 @@ class LocalQuittingDuringSharePromptsWarningTest(unittest.TestCase, GuiShareTest
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(False, True)

--- a/tests/local_onionshare_receive_mode_sender_closed_test.py
+++ b/tests/local_onionshare_receive_mode_sender_closed_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -15,6 +16,7 @@ class LocalReceiveModeSenderClosedTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_tests(False, True)

--- a/tests/local_onionshare_receive_mode_timer_test.py
+++ b/tests/local_onionshare_receive_mode_timer_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -16,6 +17,7 @@ class LocalReceiveModeTimerTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_timer_tests(False)

--- a/tests/local_onionshare_receive_mode_upload_non_writable_dir_test.py
+++ b/tests/local_onionshare_receive_mode_upload_non_writable_dir_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -15,6 +16,7 @@ class LocalReceiveModeUnwritableTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_unwritable_dir_tests(False, True)

--- a/tests/local_onionshare_receive_mode_upload_public_mode_non_writable_dir_test.py
+++ b/tests/local_onionshare_receive_mode_upload_public_mode_non_writable_dir_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -16,6 +17,7 @@ class LocalReceivePublicModeUnwritableTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_unwritable_dir_tests(True, True)

--- a/tests/local_onionshare_receive_mode_upload_public_mode_test.py
+++ b/tests/local_onionshare_receive_mode_upload_public_mode_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -16,6 +17,7 @@ class LocalReceiveModePublicModeTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_tests(True, True)

--- a/tests/local_onionshare_receive_mode_upload_test.py
+++ b/tests/local_onionshare_receive_mode_upload_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiReceiveTest import GuiReceiveTest
@@ -15,6 +16,7 @@ class LocalReceiveModeTest(unittest.TestCase, GuiReceiveTest):
     def tearDownClass(cls):
         GuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_receive_mode_tests(False, True)

--- a/tests/local_onionshare_settings_dialog_legacy_tor_test.py
+++ b/tests/local_onionshare_settings_dialog_legacy_tor_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from onionshare import strings
@@ -14,6 +15,7 @@ class SettingsGuiTest(unittest.TestCase, SettingsGuiBaseTest):
     def tearDownClass(cls):
         SettingsGuiBaseTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui_legacy_tor(self):
         self.gui.onion = OnionStub(True, False)
         self.gui.reload_settings()

--- a/tests/local_onionshare_settings_dialog_no_tor_test.py
+++ b/tests/local_onionshare_settings_dialog_no_tor_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from onionshare import strings
@@ -14,6 +15,7 @@ class SettingsGuiTest(unittest.TestCase, SettingsGuiBaseTest):
     def tearDownClass(cls):
         SettingsGuiBaseTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui_no_tor(self):
         self.gui.onion = OnionStub(False, False)
         self.gui.reload_settings()

--- a/tests/local_onionshare_settings_dialog_v3_tor_test.py
+++ b/tests/local_onionshare_settings_dialog_v3_tor_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from onionshare import strings
@@ -14,6 +15,7 @@ class SettingsGuiTest(unittest.TestCase, SettingsGuiBaseTest):
     def tearDownClass(cls):
         SettingsGuiBaseTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui_v3_tor(self):
         self.gui.onion = OnionStub(True, True)
         self.gui.reload_settings()

--- a/tests/local_onionshare_share_mode_download_public_mode_test.py
+++ b/tests/local_onionshare_share_mode_download_public_mode_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -15,6 +16,7 @@ class LocalShareModePublicModeTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(True, False)

--- a/tests/local_onionshare_share_mode_download_stay_open_test.py
+++ b/tests/local_onionshare_share_mode_download_stay_open_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -15,6 +16,7 @@ class LocalShareModeStayOpenTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(False, True)

--- a/tests/local_onionshare_share_mode_download_test.py
+++ b/tests/local_onionshare_share_mode_download_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -14,6 +15,7 @@ class LocalShareModeTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_tests(False, False)

--- a/tests/local_onionshare_share_mode_large_download_test.py
+++ b/tests/local_onionshare_share_mode_large_download_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -14,6 +15,7 @@ class LocalShareModeLargeDownloadTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_large_file_tests(False, True)

--- a/tests/local_onionshare_share_mode_slug_persistent_test.py
+++ b/tests/local_onionshare_share_mode_slug_persistent_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -18,6 +19,7 @@ class LocalShareModePersistentSlugTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_persistent_tests(False, True)

--- a/tests/local_onionshare_share_mode_timer_test.py
+++ b/tests/local_onionshare_share_mode_timer_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -16,6 +17,7 @@ class LocalShareModeTimerTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_timer_tests(False)

--- a/tests/local_onionshare_share_mode_timer_too_short_test.py
+++ b/tests/local_onionshare_share_mode_timer_too_short_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 from PyQt5 import QtCore, QtTest
 
@@ -17,6 +18,7 @@ class LocalShareModeTimerTooShortTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_setup_tests()

--- a/tests/local_onionshare_share_mode_unreadable_file_test.py
+++ b/tests/local_onionshare_share_mode_unreadable_file_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pytest
 import unittest
 
 from .GuiShareTest import GuiShareTest
@@ -14,6 +15,7 @@ class LocalShareModeUnReadableFileTest(unittest.TestCase, GuiShareTest):
     def tearDownClass(cls):
         GuiShareTest.tear_down()
 
+    @pytest.mark.gui
     def test_gui(self):
         self.run_all_common_setup_tests()
         self.run_all_share_mode_unreadable_file_tests()

--- a/tests/onionshare_790_cancel_on_second_share_test.py
+++ b/tests/onionshare_790_cancel_on_second_share_test.py
@@ -9,7 +9,7 @@ class ShareModeCancelSecondShareTest(unittest.TestCase, TorGuiShareTest):
     @classmethod
     def setUpClass(cls):
         test_settings = {
-            "close_after_first_download": True 
+            "close_after_first_download": True
         }
         cls.gui = TorGuiShareTest.set_up(test_settings)
 
@@ -17,6 +17,7 @@ class ShareModeCancelSecondShareTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_receive_mode_upload_public_mode_test.py
+++ b/tests/onionshare_receive_mode_upload_public_mode_test.py
@@ -17,6 +17,7 @@ class ReceiveModeTest(unittest.TestCase, TorGuiReceiveTest):
     def tearDownClass(cls):
         TorGuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_receive_mode_upload_test.py
+++ b/tests/onionshare_receive_mode_upload_test.py
@@ -16,6 +16,7 @@ class ReceiveModeTest(unittest.TestCase, TorGuiReceiveTest):
     def tearDownClass(cls):
         TorGuiReceiveTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_cancel_share_test.py
+++ b/tests/onionshare_share_mode_cancel_share_test.py
@@ -15,6 +15,7 @@ class ShareModeCancelTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_download_public_mode_test.py
+++ b/tests/onionshare_share_mode_download_public_mode_test.py
@@ -16,6 +16,7 @@ class ShareModePublicModeTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_download_stay_open_test.py
+++ b/tests/onionshare_share_mode_download_stay_open_test.py
@@ -16,6 +16,7 @@ class ShareModeStayOpenTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_download_test.py
+++ b/tests/onionshare_share_mode_download_test.py
@@ -15,6 +15,7 @@ class ShareModeTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_persistent_test.py
+++ b/tests/onionshare_share_mode_persistent_test.py
@@ -20,6 +20,7 @@ class ShareModePersistentSlugTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_stealth_test.py
+++ b/tests/onionshare_share_mode_stealth_test.py
@@ -17,6 +17,7 @@ class ShareModeStealthTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_timer_test.py
+++ b/tests/onionshare_share_mode_timer_test.py
@@ -17,6 +17,7 @@ class ShareModeTimerTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_tor_connection_killed_test.py
+++ b/tests/onionshare_share_mode_tor_connection_killed_test.py
@@ -11,6 +11,7 @@ class ShareModeTorConnectionKilledTest(unittest.TestCase, TorGuiShareTest):
         }
         cls.gui = TorGuiShareTest.set_up(test_settings)
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()

--- a/tests/onionshare_share_mode_v2_onion_test.py
+++ b/tests/onionshare_share_mode_v2_onion_test.py
@@ -16,6 +16,7 @@ class ShareModeV2OnionTest(unittest.TestCase, TorGuiShareTest):
     def tearDownClass(cls):
         TorGuiShareTest.tear_down()
 
+    @pytest.mark.gui
     @pytest.mark.tor
     def test_gui(self):
         self.run_all_common_setup_tests()


### PR DESCRIPTION
Will resolve #803.

I added `python3` to `Build-Depends`, which makes it so running this doesn't crash early on:

```sh
python3 setup.py --command-packages=stdeb.command bdist_deb
```

However, there's another problem. Now when I run that, it automatically runs the tests, including GUI tests. And because it's not running them with `xvfb-run`, in a desktop environment it pops up tons of OnionShare windows. And also, I'm not sure why, but I believe because of the environment the tests are being run in, many of them fail.

I like the idea of tests passing before building a `.deb`, but the GUI tests take a long time to run, and the popping up windows thing is quite annoying. I wonder if it might make more sense to only run the non-GUI tests? I don't know how to tell `pybuild` what tests to run -- it appears to just execute this as part of the build:

```
I: pybuild base:217: cd '/home/user/code/onionshare/deb_dist/onionshare-2.0~dev2/.pybuild/cpython3_3.7_onionshare/build'; python3.7 -m pytest tests
```

Right now running the tests runs the local GUI tests, but you need to pass `--runtor` to run the Tor GUI tests. We could change the tests so that you need to pass `--rungui` to run any of the GUI tests, and otherwise it doesn't run them. @mig5 what do you think about that solution?