### PR TITLE
Give visual feedback while starting

### DIFF
--- a/install/onionshare.desktop
+++ b/install/onionshare.desktop
@@ -12,3 +12,5 @@ Categories=Network;FileTransfer;
 Keywords=tor;anonymity;privacy;onion service;file sharing;file hosting;
 Keywords[da]=tor;anonymitet;privatliv;onion-tjeneste;fildeling;filhosting;
 Keywords[de]=tor;Anonymität;Privatsphäre;Onion-Service;File-Sharing;File-Hosting;
+StartupNotify=true
+StartupWMClass=onionshare


### PR DESCRIPTION
While doing usability testing for Tails (https://tails.boum.org/) or getting feedback from
users, we realized how important it was to give feedback very quickly
after the user chooses to start an application. The usual mechanism
for this in GNOME is to change the mouse cursor into a spinner as soon
as the user chooses the application from a menu or from the activities
overview.

For example, we've seen time after time people opening the same
application several times when its launcher lacked this feedback.

OnionShare doesn't provide this feedback but I think it's easy to fix.

Even when an application usually starts fast, there might be some
circumstances when it will be a bit slower to start (live operating
systems like Tails is one of them but it might happen on any busy
system).

The Freedesktop specification for such feedback is to uses a
combination of `StartupNotify` and `StartupWMClass`.

See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
