### PR TITLE
Don't show empty transfers in the receive mode UI

### DIFF
--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -67,7 +67,7 @@ class ReceiveModeWeb(object):
             receive_mode_dir = os.path.join(self.common.settings.get('data_dir'), date_dir, time_dir)
             valid = True
             try:
-                os.makedirs(receive_mode_dir, 0o700)
+                os.makedirs(receive_mode_dir, 0o700, exist_ok=True)
             except PermissionError:
                 self.web.add_request(self.web.REQUEST_ERROR_DATA_DIR_CANNOT_CREATE, request.path, {
                     "receive_mode_dir": receive_mode_dir

--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -275,11 +275,8 @@ class ReceiveModeRequest(Request):
                     strings._("receive_mode_upload_starting").format(self.web.common.human_readable_filesize(self.content_length))
                 ))
 
-                # Tell the GUI
-                self.web.add_request(self.web.REQUEST_STARTED, self.path, {
-                    'id': self.upload_id,
-                    'content_length': self.content_length
-                })
+                # Don't tell the GUI that a request has started until we start receiving files
+                self.told_gui_about_request = False
 
                 self.web.receive_mode.uploads_in_progress.append(self.upload_id)
 
@@ -291,6 +288,14 @@ class ReceiveModeRequest(Request):
         writable stream.
         """
         if self.upload_request:
+            if not self.told_gui_about_request:
+                # Tell the GUI about the request
+                self.web.add_request(self.web.REQUEST_STARTED, self.path, {
+                    'id': self.upload_id,
+                    'content_length': self.content_length
+                })
+                self.told_gui_about_request = True
+
             self.progress[filename] = {
                 'uploaded_bytes': 0,
                 'complete': False

--- a/onionshare_gui/mode/history.py
+++ b/onionshare_gui/mode/history.py
@@ -355,13 +355,15 @@ class HistoryItemList(QtWidgets.QScrollArea):
         """
         Update an item.  Override this method.
         """
-        self.items[id].update(data)
+        if id in self.items:
+            self.items[id].update(data)
 
     def cancel(self, id):
         """
         Cancel an item.  Override this method.
         """
-        self.items[id].cancel()
+        if id in self.items:
+            self.items[id].cancel()
 
     def reset(self):
         """

--- a/tests/GuiReceiveTest.py
+++ b/tests/GuiReceiveTest.py
@@ -52,6 +52,28 @@ class GuiReceiveTest(GuiBaseTest):
         response = requests.get('http://127.0.0.1:{}/close'.format(self.gui.app.port))
         self.assertEqual(response.status_code, 404)
 
+    def uploading_zero_files_shouldnt_change_ui(self, mode, public_mode):
+        '''If you submit the receive mode form without selecting any files, the UI shouldn't get updated'''
+        if not public_mode:
+            path = 'http://127.0.0.1:{}/{}/upload'.format(self.gui.app.port, self.gui.receive_mode.web.slug)
+        else:
+            path = 'http://127.0.0.1:{}/upload'.format(self.gui.app.port)
+
+        # What were the counts before submitting the form?
+        before_in_progress_count = mode.history.in_progress_count
+        before_completed_count = mode.history.completed_count
+        before_number_of_history_items = len(mode.history.item_list.items)
+
+        # Click submit without including any files a few times
+        response = requests.post(path, files={})
+        response = requests.post(path, files={})
+        response = requests.post(path, files={})
+
+        # The counts shouldn't change
+        self.assertEqual(mode.history.in_progress_count, before_in_progress_count)
+        self.assertEqual(mode.history.completed_count, before_completed_count)
+        self.assertEqual(len(mode.history.item_list.items), before_number_of_history_items)
+
     def run_receive_mode_sender_closed_tests(self, public_mode):
         '''Test that the share can be stopped by the sender in receive mode'''
         if not public_mode:
@@ -97,6 +119,7 @@ class GuiReceiveTest(GuiBaseTest):
         self.counter_incremented(self.gui.receive_mode, 3)
         self.upload_file(public_mode, '/tmp/testdir/test', 'test')
         self.counter_incremented(self.gui.receive_mode, 4)
+        self.uploading_zero_files_shouldnt_change_ui(self.gui.receive_mode, public_mode)
         self.history_indicator(self.gui.receive_mode, public_mode)
         self.server_is_stopped(self.gui.receive_mode, False)
         self.web_server_is_stopped()


### PR DESCRIPTION
If you start a receive mode server, load the page in Tor Browser, and then click "Send Files" without selecting any to send, the history widget adds a blank transfer to the history, that says "Transferred [datetime]" but doesn't include any files.

This PR just simply doesn't display anything if someone clicks "Send Files" without first browsing for files.