### PR TITLE
Receive mode partial download

### DIFF
--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -82,7 +82,14 @@ class ReceiveModeWeb(object):
 
             if request.upload_error:
                 self.common.log('ReceiveModeWeb', 'define_routes', '/upload, there was an upload error')
+
+                self.web.add_request(self.web.REQUEST_ERROR_DATA_DIR_CANNOT_CREATE, request.path, {
+                    "receive_mode_dir": request.receive_mode_dir
+                })
+                print(strings._('error_cannot_create_data_dir').format(request.receive_mode_dir))
+
                 flash('Error uploading, please inform the OnionShare user', 'error')
+
                 if self.common.settings.get('public_mode'):
                     return redirect('/')
                 else:

--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -158,10 +158,11 @@ class ReceiveModeFile(object):
         self.onionshare_write_func = write_func
         self.onionshare_close_func = close_func
 
-        self.filename = os.path.join(self.onionshare_request.receive_mode_dir, secure_filename(filename))
+        self.filename = os.path.join(self.onionshare_request.receive_mode_dir, filename)
         self.filename_in_progress = '{}.part'.format(self.filename)
 
         # Open the file
+        self.upload_error = False
         try:
             self.f = open(self.filename_in_progress, 'wb+')
         except:
@@ -315,6 +316,8 @@ class ReceiveModeRequest(Request):
                 self.web.receive_mode.uploads_in_progress.append(self.upload_id)
 
                 self.told_gui_about_request = True
+
+            filename = secure_filename(filename)
 
             self.progress[filename] = {
                 'uploaded_bytes': 0,

--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -198,21 +198,24 @@ class ReceiveModeFile(object):
 
         try:
             bytes_written = self.f.write(b)
+            self.onionshare_write_func(self.onionshare_filename, bytes_written)
+
         except:
-            # If we can't write the file, close early
             self.upload_error = True
-            return
-        self.onionshare_write_func(self.onionshare_filename, bytes_written)
 
     def close(self):
         """
         Custom close method that calls out to onionshare_close_func
         """
-        self.f.close()
+        try:
+            self.f.close()
 
-        if not self.upload_error:
-            # Rename the in progress file to the final filename
-            os.rename(self.filename_in_progress, self.filename)
+            if not self.upload_error:
+                # Rename the in progress file to the final filename
+                os.rename(self.filename_in_progress, self.filename)
+
+        except:
+            self.upload_error = True
 
         self.onionshare_close_func(self.onionshare_filename)
 

--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -173,7 +173,7 @@ class ReceiveModeFile(object):
         try:
             self.f = open(self.filename_in_progress, 'wb+')
         except:
-            # This will only happen if someone is messaging with the data dir while
+            # This will only happen if someone is messing with the data dir while
             # OnionShare is running, but if it does make sure to throw an error
             self.upload_error = True
             self.f = tempfile.TemporaryFile('wb+')

--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -193,7 +193,7 @@ class ReceiveModeFile(object):
         """
         if self.upload_error or (not self.onionshare_request.stop_q.empty()):
             self.close()
-            self.onionshare_request.close(self.upload_error)
+            self.onionshare_request.close()
             return
 
         try:
@@ -217,7 +217,7 @@ class ReceiveModeFile(object):
         except:
             self.upload_error = True
 
-        self.onionshare_close_func(self.onionshare_filename)
+        self.onionshare_close_func(self.onionshare_filename, self.upload_error)
 
 
 class ReceiveModeRequest(Request):

--- a/onionshare/web/web.py
+++ b/onionshare/web/web.py
@@ -14,7 +14,7 @@ from flask import Flask, request, render_template, abort, make_response, __versi
 from .. import strings
 
 from .share_mode import ShareModeWeb
-from .receive_mode import ReceiveModeWeb, ReceiveModeWSGIMiddleware, ReceiveModeTemporaryFile, ReceiveModeRequest
+from .receive_mode import ReceiveModeWeb, ReceiveModeWSGIMiddleware, ReceiveModeRequest
 
 
 # Stub out flask's show_server_banner function, to avoiding showing warnings that


### PR DESCRIPTION
This PR refactors `ReceiveModeWeb` to make is to files get written to the OnionShare data dir (by default `~/OnionShare`) immediately while the Tor Browser user is sending them, instead of after the transfer is complete. While the file is in progress, it has a `.part` file extension, which gets removed when the transfer is complete.

In order to make this work, much of the receive mode web logic moved from the `upload_logic` flask route into the custom `ReceiveModeRequest` class, as well as the `ReceiveModeFile` class (which used to be called `ReceiveModeTemporaryFile`).

I think this is quite a bit nicer, and lets users watch uploads on the filesystem as they're happening. And if an upload cancels early, the user gets to at least access what had uploaded so far.