### PR TITLE
Don't clear in-progress transfers from the History list

### DIFF
--- a/onionshare_gui/mode/history.py
+++ b/onionshare_gui/mode/history.py
@@ -90,6 +90,7 @@ class ShareHistoryItem(HistoryItem):
         self.downloaded_bytes = 0
         self.started = time.time()
         self.started_dt = datetime.fromtimestamp(self.started)
+        self.status = 'started'
 
         # Label
         self.label = QtWidgets.QLabel(strings._('gui_all_modes_transfer_started').format(self.started_dt.strftime("%b %d, %I:%M%p")))
@@ -124,6 +125,7 @@ class ShareHistoryItem(HistoryItem):
 
             # Change the label
             self.label.setText(self.get_finished_label_text(self.started_dt))
+            self.status = 'finished'
 
         else:
             elapsed = time.time() - self.started
@@ -142,6 +144,7 @@ class ShareHistoryItem(HistoryItem):
 
     def cancel(self):
         self.progress_bar.setFormat(strings._('gui_canceled'))
+        self.status = 'canceled'
 
     @property
     def estimated_time_remaining(self):
@@ -501,8 +504,7 @@ class History(QtWidgets.QWidget):
         Reset all items.
         """
         self.item_list.reset()
-
-        if not any(self.item_list.items):
+        if len(self.item_list.items) == 0:
             # Hide not empty, show empty
             self.not_empty.hide()
             self.empty.show()

--- a/onionshare_gui/mode/history.py
+++ b/onionshare_gui/mode/history.py
@@ -31,6 +31,10 @@ class HistoryItem(QtWidgets.QWidget):
     """
     The base history item
     """
+    STATUS_STARTED = 0
+    STATUS_FINISHED = 1
+    STATUS_CANCELED = 2
+
     def __init__(self):
         super(HistoryItem, self).__init__()
 
@@ -90,7 +94,7 @@ class ShareHistoryItem(HistoryItem):
         self.downloaded_bytes = 0
         self.started = time.time()
         self.started_dt = datetime.fromtimestamp(self.started)
-        self.status = 'started'
+        self.status = HistoryItem.STATUS_STARTED
 
         # Label
         self.label = QtWidgets.QLabel(strings._('gui_all_modes_transfer_started').format(self.started_dt.strftime("%b %d, %I:%M%p")))
@@ -125,7 +129,7 @@ class ShareHistoryItem(HistoryItem):
 
             # Change the label
             self.label.setText(self.get_finished_label_text(self.started_dt))
-            self.status = 'finished'
+            self.status = HistoryItem.STATUS_FINISHED
 
         else:
             elapsed = time.time() - self.started
@@ -144,7 +148,7 @@ class ShareHistoryItem(HistoryItem):
 
     def cancel(self):
         self.progress_bar.setFormat(strings._('gui_canceled'))
-        self.status = 'canceled'
+        self.status = HistoryItem.STATUS_CANCELED
 
     @property
     def estimated_time_remaining(self):
@@ -240,7 +244,7 @@ class ReceiveHistoryItem(HistoryItem):
         self.id = id
         self.content_length = content_length
         self.started = datetime.now()
-        self.status = 'started'
+        self.status = HistoryItem.STATUS_STARTED
 
         # Label
         self.label = QtWidgets.QLabel(strings._('gui_all_modes_transfer_started').format(self.started.strftime("%b %d, %I:%M%p")))
@@ -318,7 +322,7 @@ class ReceiveHistoryItem(HistoryItem):
 
         elif data['action'] == 'finished':
             # Change the status
-            self.status = 'finished'
+            self.status = HistoryItem.STATUS_FINISHED
 
             # Hide the progress bar
             self.progress_bar.hide()
@@ -328,7 +332,7 @@ class ReceiveHistoryItem(HistoryItem):
 
         elif data['action'] == 'canceled':
             # Change the status
-            self.status = 'canceled'
+            self.status = HistoryItem.STATUS_CANCELED
 
             # Hide the progress bar
             self.progress_bar.hide()
@@ -400,7 +404,7 @@ class HistoryItemList(QtWidgets.QScrollArea):
         Reset all items, emptying the list.  Override this method.
         """
         for key, item in self.items.copy().items():
-            if item.status != 'started':
+            if item.status != HistoryItem.STATUS_STARTED:
                 self.items_layout.removeWidget(item)
                 item.close()
                 del self.items[key]


### PR DESCRIPTION
Should fix #902 

Note: apparently one has to [copy a dict](https://stackoverflow.com/questions/5844672/delete-an-element-from-a-dictionary) to work on it in order to remove an item from the original dict