### PR TITLE
Update the GUI when the browser has canceled an upload in Receive Mode. Don't increment the completed counter

### DIFF
--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -332,14 +332,14 @@ class ReceiveModeRequest(Request):
 
                 self.told_gui_about_request = True
 
-            filename = secure_filename(filename)
+            self.filename = secure_filename(filename)
 
-            self.progress[filename] = {
+            self.progress[self.filename] = {
                 'uploaded_bytes': 0,
                 'complete': False
             }
 
-        f = ReceiveModeFile(self, filename, self.file_write_func, self.file_close_func)
+        f = ReceiveModeFile(self, self.filename, self.file_write_func, self.file_close_func)
         if f.upload_error:
             self.web.common.log('ReceiveModeRequest', '_get_file_stream', 'Error creating file')
             self.upload_error = True
@@ -362,7 +362,7 @@ class ReceiveModeRequest(Request):
             if self.told_gui_about_request:
                 upload_id = self.upload_id
 
-                if not self.web.stop_q.empty():
+                if not self.web.stop_q.empty() or not self.progress[self.filename]['complete']:
                     # Inform the GUI that the upload has canceled
                     self.web.add_request(self.web.REQUEST_UPLOAD_CANCELED, self.path, {
                         'id': upload_id

--- a/onionshare_gui/mode/receive_mode/__init__.py
+++ b/onionshare_gui/mode/receive_mode/__init__.py
@@ -198,9 +198,7 @@ class ReceiveMode(Mode):
         self.history.update(event["data"]["id"], {
             'action': 'canceled'
         })
-        self.history.completed_count += 1
         self.history.in_progress_count -= 1
-        self.history.update_completed()
         self.history.update_in_progress()
 
     def on_reload_settings(self):


### PR DESCRIPTION
Seems to fix #903 .  I hope it's ok to set `self.filename` here so that I can access it in the `close()` function in order to activate the 'REQUEST_UPLOAD_CANCELED' event.

I also didn't like that the 'completed' (green tick) counter incremented on a canceled upload. I think it's better to keep that counter at the original value so that it's only counting successful uploads. So I removed that bit of code too.