### PR TITLE
Always reset the slug to an empty string when the web server stops

### DIFF
--- a/onionshare/web/web.py
+++ b/onionshare/web/web.py
@@ -263,6 +263,9 @@ class Web(object):
         # Let the mode know that the user stopped the server
         self.stop_q.put(True)
 
+        # Reset any slug that was in use
+        self.slug = ''
+
         # To stop flask, load http://127.0.0.1:<port>/<shutdown_slug>/shutdown
         if self.running:
             try:


### PR DESCRIPTION
Probably fixes #835 