### PR TITLE
On a folder name collision, make sure we update the self.receive_mode_dir attribute

### DIFF
--- a/onionshare/web/receive_mode.py
+++ b/onionshare/web/receive_mode.py
@@ -297,6 +297,7 @@ class ReceiveModeRequest(Request):
                         new_receive_mode_dir = '{}-{}'.format(self.receive_mode_dir, i)
                         try:
                             os.makedirs(new_receive_mode_dir, 0o700, exist_ok=False)
+                            self.receive_mode_dir = new_receive_mode_dir
                             break
                         except OSError:
                             pass


### PR DESCRIPTION
When there is a folder collision (e.g two uploads starting at exactly the same second), we create a new folder with a -N numbered suffix.

However, we weren't updating `self.receive_mode_dir` attribute to this new folder.

If two files were being uploaded at exactly the same second, the second folder would be created, but one of the files would actually be uploaded to the original folder (without the suffix), and clobber the other file.

I discovered this while writing tests for exactly this 'rename' logic. But I was able to even test this by hand by opening two tabs of the same Receive Mode service in local mode, and click 'Send' in a rapid-fire (Ctrl Tab between the first and second tab) of two files called test.txt but with different contents, if I was fast enough. The 'second' file clobbered the first in the first's folder.

This fixes the problem, and I also introduced uploading two files at once into the general Receive Mode tests (the test explicitly looks for a file in the folder with the -1 suffix in its name, and it fails without this patch).