### PR TITLE
Allow the bundled Tor connection timeout to be configurable from the CLI

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -54,6 +54,7 @@ def main(cwd=None):
     parser.add_argument('--local-only', action='store_true', dest='local_only', help=strings._("help_local_only"))
     parser.add_argument('--stay-open', action='store_true', dest='stay_open', help=strings._("help_stay_open"))
     parser.add_argument('--shutdown-timeout', metavar='<int>', dest='shutdown_timeout', default=0, help=strings._("help_shutdown_timeout"))
+    parser.add_argument('--connect-timeout', metavar='<int>', dest='connect_timeout', default=120, help=strings._("help_connect_timeout"))
     parser.add_argument('--stealth', action='store_true', dest='stealth', help=strings._("help_stealth"))
     parser.add_argument('--receive', action='store_true', dest='receive', help=strings._("help_receive"))
     parser.add_argument('--config', metavar='config', default=False, help=strings._('help_config'))
@@ -69,6 +70,7 @@ def main(cwd=None):
     debug = bool(args.debug)
     stay_open = bool(args.stay_open)
     shutdown_timeout = int(args.shutdown_timeout)
+    connect_timeout = int(args.connect_timeout)
     stealth = bool(args.stealth)
     receive = bool(args.receive)
     config = args.config
@@ -111,7 +113,7 @@ def main(cwd=None):
     # Start the Onion object
     onion = Onion(common)
     try:
-        onion.connect(custom_settings=False, config=config)
+        onion.connect(custom_settings=False, config=config, connect_timeout=connect_timeout)
     except KeyboardInterrupt:
         print("")
         sys.exit()

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -283,7 +283,9 @@ class Onion(object):
                 if self.settings.get('tor_bridges_use_custom_bridges') or \
                    self.settings.get('tor_bridges_use_obfs4') or \
                    self.settings.get('tor_bridges_use_meek_lite_azure'):
-                    connect_timeout = 150
+                       # Only override timeout if a custom timeout has not been passed in
+                       if connect_timeout == 120:
+                           connect_timeout = 150
                 if time.time() - start_ts > connect_timeout:
                     print("")
                     try:

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -152,7 +152,7 @@ class Onion(object):
         # Start out not connected to Tor
         self.connected_to_tor = False
 
-    def connect(self, custom_settings=False, config=False, tor_status_update_func=None):
+    def connect(self, custom_settings=False, config=False, tor_status_update_func=None, connect_timeout=120):
         self.common.log('Onion', 'connect')
 
         # Either use settings that are passed in, or use them from common
@@ -284,13 +284,13 @@ class Onion(object):
                    self.settings.get('tor_bridges_use_obfs4') or \
                    self.settings.get('tor_bridges_use_meek_lite_azure'):
                     connect_timeout = 150
-                else:
-                    # Timeout after 120 seconds
-                    connect_timeout = 120
                 if time.time() - start_ts > connect_timeout:
                     print("")
-                    self.tor_proc.terminate()
-                    raise BundledTorTimeout(strings._('settings_error_bundled_tor_timeout'))
+                    try:
+                        self.tor_proc.terminate()
+                        raise BundledTorTimeout(strings._('settings_error_bundled_tor_timeout'))
+                    except FileNotFoundError:
+                        pass
 
         elif self.settings.get('connection_type') == 'automatic':
             # Automatically try to guess the right way to connect to Tor Browser

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -16,6 +16,7 @@
     "help_local_only": "Don't use Tor (only for development)",
     "help_stay_open": "Continue sharing after files have been sent",
     "help_shutdown_timeout": "Stop sharing after a given amount of seconds",
+    "help_connect_timeout": "Give up connecting to Tor after a given amount of seconds (default: 120)",
     "help_stealth": "Use client authorization (advanced)",
     "help_receive": "Receive shares instead of sending them",
     "help_debug": "Log OnionShare errors to stdout, and web errors to disk",


### PR DESCRIPTION
Fixes #832 

In the process of testing it, I came across this StackTrace when the Tor proc is reaped:

```
user@onionshare:~/git/onionshare$ ./dev_scripts/onionshare --connect-timeout 5 BUILD.md 
OnionShare 2.0 | https://onionshare.org/
Connecting to the Tor network: 25% - Loading networkstatus consensus
Taking too long to connect to Tor. Maybe you aren't connected to the Internet, or have an inaccurate system clock?
Exception ignored in: <finalize object at 0x780b190ab200; dead>
Traceback (most recent call last):
  File "/usr/lib/python3.5/weakref.py", line 548, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "/usr/lib/python3.5/tempfile.py", line 936, in _cleanup
    _rmtree(name)
  File "/usr/lib/python3.5/shutil.py", line 480, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/usr/lib/python3.5/shutil.py", line 438, in _rmtree_safe_fd
    onerror(os.unlink, fullname, sys.exc_info())
  File "/usr/lib/python3.5/shutil.py", line 436, in _rmtree_safe_fd
    os.unlink(name, dir_fd=topfd)
FileNotFoundError: [Errno 2] No such file or directory: 'cookie'
```

I 'fix' (ignore) that too as part of this PR. I think this therefore also solves the downstream Debian bug report https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915869