### PR TITLE
Save the onion address, slug and optionally hidservauth (if applicable) to the json settings if --debug is passed

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -18,7 +18,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os, sys, time, argparse, threading
+import argparse
+import json
+import os
+import sys
+import threading
+import time
 
 from . import strings
 from .common import Common
@@ -173,6 +178,15 @@ def main(cwd=None):
         else:
             url = 'http://{0:s}/{1:s}'.format(app.onion_host, web.slug)
 
+        # Save the onionshare details to json for programmatic use
+        if debug:
+            common.settings.set('debug_onion', app.onion_host)
+            common.settings.set('debug_url', url)
+            if not common.settings.get('public_mode'):
+                common.settings.set('debug_slug', web.slug)
+            if stealth:
+                common.settings.set('debug_hidservauth', app.auth_string)
+            common.settings.save()
         print('')
         if mode == 'receive':
             print(strings._('receive_mode_data_dir').format(common.settings.get('data_dir')))

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -535,6 +535,10 @@ class Onion(object):
         except:
             pass
         self.service_id = None
+        debug_settings = [ 'debug_onion', 'debug_url', 'debug_slug', 'debug_hidservauth' ]
+        for key in debug_settings:
+            self.settings.set(key, '')
+        self.settings.save()
 
         if stop_tor:
             # Stop tor process

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -537,8 +537,8 @@ class Onion(object):
         self.service_id = None
         debug_settings = [ 'debug_onion', 'debug_url', 'debug_slug', 'debug_hidservauth' ]
         for key in debug_settings:
-            self.settings.set(key, '')
-        self.settings.save()
+            self.common.settings.set(key, '')
+        self.common.settings.save()
 
         if stop_tor:
             # Stop tor process

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -99,7 +99,11 @@ class Settings(object):
             'slug': '',
             'hidservauth_string': '',
             'data_dir': self.build_default_data_dir(),
-            'locale': None # this gets defined in fill_in_defaults()
+            'locale': None, # this gets defined in fill_in_defaults()
+            'debug_onion': '',
+            'debug_url': '',
+            'debug_slug': '',
+            'debug_hidservauth': ''
         }
         self._settings = {}
         self.fill_in_defaults()

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -18,7 +18,7 @@
     "help_shutdown_timeout": "Stop sharing after a given amount of seconds",
     "help_stealth": "Use client authorization (advanced)",
     "help_receive": "Receive shares instead of sending them",
-    "help_debug": "Log OnionShare errors to stdout, and web errors to disk",
+    "help_debug": "Log OnionShare errors to stdout, onion details to the json settings file, and web errors to disk",
     "help_filename": "List of files or folders to share",
     "help_config": "Custom JSON config file location (optional)",
     "gui_drag_and_drop": "Drag and drop files and folders\nto start sharing",

--- a/tests/test_onionshare_settings.py
+++ b/tests/test_onionshare_settings.py
@@ -65,7 +65,11 @@ class TestSettings:
             'slug': '',
             'hidservauth_string': '',
             'data_dir': os.path.expanduser('~/OnionShare'),
-            'public_mode': False
+            'public_mode': False,
+            'debug_onion': '',
+            'debug_url': '',
+            'debug_slug': '',
+            'debug_hidservauth': ''
         }
         for key in settings_obj._settings:
             # Skip locale, it will not always default to the same thing


### PR DESCRIPTION
I was wondering what you thought of this solution to #816 

I thought if the user passed the `--debug` flag, we could simply save the new onion address, slug and optionally hidservauth to the json file. This is simpler than doing any other sort of json output since we already have our json right there.

It wouldn't interfere with persistence in the settings json, as these have their own keys prefixed with `debug_`

```
user@onionshare:~$ cat .config/onionshare/onionshare.json | json_pp | grep debug_
   "debug_slug" : "trout-playmate",
   "debug_hidservauth" : "",
   "debug_url" : "http://tglebv3kegvpkfh76ljhhq43zw4idu2wrzgrjzygtkbkg4whpztmoqyd.onion/trout-playmate",
   "debug_onion" : "tglebv3kegvpkfh76ljhhq43zw4idu2wrzgrjzygtkbkg4whpztmoqyd.onion",
```

It would allow the programmer to start an onionshare via CLI, perhaps with a wrapper Python script that calls it via subprocess (note: perhaps with a configurable timeout as per #941), wait for that length of time, then try a json lookup of these keys from the settings file (since we know the settings file's name and location) to obtain the values.

Felt easier to bundle it with 'debug' mode than add yet another CLI flag or other logic. But I'm open to it being rejected, it feels like it will rarely be used :)

And, of course, this is just for CLI use, since it's assumed only advanced users with unusual use cases would need it, e.g for programmatic purposes alone..