### PR TITLE
Build docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -135,7 +135,7 @@ Open a command prompt, cd to the onionshare folder, and install dependencies wit
 pip install -r install\requirements.txt
 ```
 
-Install the Qt 5.11.3 from https://www.qt.io/download-open-source/. I downloaded `qt-unified-windows-x86-3.0.6-online.exe`. In the installer, you can skip making an account, and all you need `Qt` > `Qt 5.11.3` > `MSVC 2015 32-bit`.
+Install the Qt 5.12.1 from https://download.qt.io/archive/qt/5.12/5.12.1/. I downloaded `qt-opensource-windows-x86-5.12.1.exe`. In the installer, you can skip making an account, and all you need `Qt` > `Qt 5.12.1` > `MSVC 2017 32-bit`.
 
 After that you can try both the CLI and the GUI version of OnionShare:
 
@@ -150,14 +150,14 @@ These instructions include adding folders to the path in Windows. To do this, go
 
 Download and install the 32-bit [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48145). I downloaded `vc_redist.x86.exe`.
 
-Download and install 7-Zip from http://www.7-zip.org/download.html. I downloaded `7z1805.exe`.
+Download and install 7-Zip from http://www.7-zip.org/download.html. I downloaded `7z1900.exe`.
 
 Download and install the standalone [Windows 10 SDK](https://dev.windows.com/en-us/downloads/windows-10-sdk). Note that you may not need this if you already have Visual Studio.
 
 Add the following directories to the path:
 
-* `C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86`
-* `C:\Program Files (x86)\Windows Kits\10\Redist\10.0.17763.0\ucrt\DLLs\x86`
+* `C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86`
+* `C:\Program Files (x86)\Windows Kits\10\Redist\10.0.18362.0\ucrt\DLLs\x86`
 * `C:\Users\user\AppData\Local\Programs\Python\Python37-32\Lib\site-packages\PyQt5\Qt\bin`
 * `C:\Program Files (x86)\7-Zip`
 
@@ -169,7 +169,7 @@ OnionShare uses PyInstaller to turn the python source code into Windows executab
 
 Here's how to compile the PyInstaller bootloader:
 
-Download and install [Microsoft Build Tools for Visual Studio 2017](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017). I downloaded `vs_buildtools.exe`. In the installer, check the box next to "Visual C++ build tools". Click "Individual components", and under "Compilers, build tools and runtimes", check "Windows Universal CRT SDK". Then click install. When installation is done, you may have to reboot your computer.
+Download and install [Microsoft Build Tools for Visual Studio 2019](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019). I downloaded `vs_buildtools__265029578.1555959436.exe`. In the installer, check the box next to "Visual C++ build tools". Click "Individual components", and under "Compilers, build tools and runtimes", check "Windows Universal CRT SDK". Then click install. When installation is done, you may have to reboot your computer.
 
 Then, enable the 32-bit Visual C++ Toolset on the Command Line like this:
 
@@ -181,7 +181,7 @@ vcvars32.bat
 Make sure you have a new enough `setuptools`:
 
 ```
-pip install setuptools==40.6.3
+pip install --upgrade setuptools
 ```
 
 Now make sure you don't have PyInstaller installed from pip:

--- a/BUILD.md
+++ b/BUILD.md
@@ -307,13 +307,13 @@ Verify the release git tag:
 
 ```
 git fetch
-git tag -v [tag_name]
+git tag -v v$VERSION
 ```
 
 If the tag verifies successfully, check it out:
 
 ```
-git checkout [tag_name]
+git checkout v$VERSION
 ```
 
 ## Linux release
@@ -334,26 +334,26 @@ To make a macOS release, go to macOS build machine:
 
 - Build machine should be running macOS 10.11.6, and must have the Apple-trusted `Developer ID Application: Micah Lee` and `Developer ID Installer: Micah Lee` code-signing certificates installed
 - Verify and checkout the git tag for this release
-- Run `./install/build_osx.sh --release`; this will make a codesigned installer package called `dist/OnionShare-[version].pkg`
-- Copy `OnionShare-[version].pkg` to developer machine
+- Run `./install/build_osx.sh --release`; this will make a codesigned installer package called `dist/OnionShare-$VERSION.pkg`
+- Copy `OnionShare-$VERSION.pkg` to developer machine
 
 Then move back to the developer machine:
 
-- PGP-sign the macOS installer, `gpg --detach-sign OnionShare-[version].pkg`
+- PGP-sign the macOS installer, `gpg --detach-sign OnionShare-$VERSION.pkg`
 
 Note that once we support notarizing the macOS installer (see [this issue](https://github.com/micahflee/onionshare/issues/953)), these will be the steps instead:
 
 - Developer machine, running the latest macOS, must have an app-specific Apple ID password saved in the login keychain called `onionshare-notarize`
-- Notarize it: `xcrun altool --notarize-app --primary-bundle-id "com.micahflee.onionshare" -u "micah@micahflee.com" -p "@keychain:onionshare-notarize" --file OnionShare-[version].pkg`
+- Notarize it: `xcrun altool --notarize-app --primary-bundle-id "com.micahflee.onionshare" -u "micah@micahflee.com" -p "@keychain:onionshare-notarize" --file OnionShare-$VERSION.pkg`
 - Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "micah@micahflee.com" -p "@keychain:onionshare-notarize"`
-- After it's approved, staple the ticket: `xcrun stapler staple OnionShare-[version].pkg`
-- PGP-sign the final, notarized and stapled, `gpg --detach-sign OnionShare-[version].pkg`
+- After it's approved, staple the ticket: `xcrun stapler staple OnionShare-$VERSION.pkg`
+- PGP-sign the final, notarized and stapled, `gpg -a --detach-sign OnionShare-$VERSION.pkg`
 
 This process ends up with two final files:
 
 ```
-OnionShare-[version].pkg
-OnionShare-[version].pkg.asc
+OnionShare-$VERSION.pkg
+OnionShare-$VERSION.pkg.asc
 ```
 
 ## Windows release
@@ -362,26 +362,65 @@ To make a Windows release, go to Windows build machine:
 
 - Build machine should be running Windows 10, and have the Windows codesigning certificate installed
 - Verify and checkout the git tag for this release
-- Run `install\build_exe.bat`; this will make a codesigned installer package called `dist\onionshare-[version]-setup.exe`
-- Copy `onionshare-[version]-setup.exe` to developer machine
+- Run `install\build_exe.bat`; this will make a codesigned installer package called `dist\onionshare-$VERSION-setup.exe`
+- Copy `onionshare-$VERSION-setup.exe` to developer machine
 
 Then move back to the developer machine:
 
-- PGP-sign the Windows installer, `gpg --detach-sign onionshare-[version]-setup.exe`
+- PGP-sign the Windows installer, `gpg -a --detach-sign onionshare-$VERSION-setup.exe`
 
 This process ends up with two final files:
 
 ```
-onionshare-[version]-setup.exe
-onionshare-[version]-setup.exe.asc
+onionshare-$VERSION-setup.exe
+onionshare-$VERSION-setup.exe.asc
+```
+
+## Make a source release
+
+Make a fresh clone of the git repo:
+
+```
+cd ~/tmp
+git clone https://github.com/micahflee/onionshare.git
+```
+
+Verify the git tag, and if it verifies check it out:
+
+```
+cd onionshare
+git tag -v v$VERSION
+# (make sure tag verifies!!!)
+git checkout v$VERSION
+```
+
+Delete the `.git` folder and compress:
+
+```
+cd ..
+rm -rf onionshare/.git
+tar -cf onionshare-$VERSION.tar.gz onionshare/
+```
+
+PGP-sign the source package:
+
+```
+gpg -a --detach-sign onionshare-$VERSION.tar.gz
+```
+
+This process ends up with two final files:
+
+```
+onionshare-$VERSION.tar.gz
+onionshare-$VERSION.tar.gz.asc
 ```
 
 ## Publishing the release
 
 To publish the release:
 
-- Create a new release on GitHub, put the changelog in the description of the release, and upload all four files (the macOS installer and PGP sig, and the Windows installer and PGP sig)
-- Upload the four release files to https://onionshare.org/dist/[version]/
+- Create a new release on GitHub, put the changelog in the description of the release, and upload all six files (the macOS installer, the Windows installer, the source package, and their signatures)
+- Upload the six release files to https://onionshare.org/dist/$VERSION/
 - Update the [onionshare-website](https://github.com/micahflee/onionshare-website) repo:
   - Edit `latest-version.txt` to match the latest version
   - Update the version number and download links

--- a/BUILD.md
+++ b/BUILD.md
@@ -376,39 +376,11 @@ onionshare-$VERSION-setup.exe
 onionshare-$VERSION-setup.exe.asc
 ```
 
-## Make a source release
+## Source package
 
-Make a fresh clone of the git repo:
+To make a source package, run `./install/build_source.sh $TAG`, where `$TAG` is the the name of the signed git tag, e.g. `v2.1`.
 
-```
-cd ~/tmp
-git clone https://github.com/micahflee/onionshare.git
-```
-
-Verify the git tag, and if it verifies check it out:
-
-```
-cd onionshare
-git tag -v v$VERSION
-# (make sure tag verifies!!!)
-git checkout v$VERSION
-```
-
-Delete the `.git` folder and compress:
-
-```
-cd ..
-rm -rf onionshare/.git
-tar -cf onionshare-$VERSION.tar.gz onionshare/
-```
-
-PGP-sign the source package:
-
-```
-gpg -a --detach-sign onionshare-$VERSION.tar.gz
-```
-
-This process ends up with two final files:
+This process ends up with two final files in `dist`:
 
 ```
 onionshare-$VERSION.tar.gz

--- a/BUILD.md
+++ b/BUILD.md
@@ -339,8 +339,12 @@ To make a macOS release, go to macOS build machine:
 
 Then move back to the developer machine:
 
+- PGP-sign the macOS installer, `gpg --detach-sign OnionShare-[version].pkg`
+
+Note that once we support notarizing the macOS installer (see [this issue](https://github.com/micahflee/onionshare/issues/953)), these will be the steps instead:
+
 - Developer machine, running the latest macOS, must have an app-specific Apple ID password saved in the login keychain called `onionshare-notarize`
-- Notarize it: `crun altool --notarize-app --primary-bundle-id "com.micahflee.onionshare" -u "micah@micahflee.com" -p "@keychain:onionshare-notarize" --file OnionShare-[version].pkg`
+- Notarize it: `xcrun altool --notarize-app --primary-bundle-id "com.micahflee.onionshare" -u "micah@micahflee.com" -p "@keychain:onionshare-notarize" --file OnionShare-[version].pkg`
 - Wait for it to get approved, check status with: `xcrun altool --notarization-history 0 -u "micah@micahflee.com" -p "@keychain:onionshare-notarize"`
 - After it's approved, staple the ticket: `xcrun stapler staple OnionShare-[version].pkg`
 - PGP-sign the final, notarized and stapled, `gpg --detach-sign OnionShare-[version].pkg`

--- a/install/build_source.sh
+++ b/install/build_source.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# The script builds a source package
+# See https://github.com/micahflee/onionshare/blob/develop/BUILD.md#source-package
+
+# Usage
+display_usage() {
+	echo "Usage: $0 [tag]"
+}
+
+if [ $# -lt 1 ]
+then
+  display_usage
+  exit 1
+fi
+
+# Input validation
+TAG=$1
+
+if [ "${TAG:0:1}" != "v" ]
+then
+  echo "Tag must start with 'v' character"
+  exit 1
+fi
+
+VERSION=${TAG:1}
+
+# Make sure tag exists
+git tag | grep "^$TAG\$"
+if [ $? -ne 0 ]
+then
+  echo "Tag does not exist"
+  exit 1
+fi
+
+# Clone source
+mkdir -p build/source
+mkdir -p dist
+cd build/source
+git clone https://github.com/micahflee/onionshare.git
+cd onionshare
+
+# Verify tag
+git tag -v $TAG 2> ../verify.txt
+if [ $? -ne 0 ]
+then
+  echo "Tag does not verify"
+  exit 1
+fi
+cat ../verify.txt |grep "using RSA key 927F419D7EC82C2F149C1BD1403C2657CD994F73"
+if [ $? -ne 0 ]
+then
+  echo "Tag signed with wrong key"
+  exit 1
+fi
+cat ../verify.txt |grep "^gpg: Good signature from"
+if [ $? -ne 0 ]
+then
+  echo "Tag verification missing 'Good signature from'"
+  exit 1
+fi
+
+# Checkout code
+git checkout $TAG
+
+# Delete .git, compress, and PGP sign
+cd ..
+rm -rf onionshare/.git
+tar -cf onionshare-$VERSION.tar.gz onionshare/
+gpg -a --detach-sign onionshare-$VERSION.tar.gz
+
+# Move source package to dist
+cd ../..
+mv build/source/onionshare-$VERSION.tar.gz dist
+mv build/source/onionshare-$VERSION.tar.gz.asc dist
+
+# Clean up
+rm -rf build/source/onionshare
+rm build/source/verify.txt
+
+echo "Source package complete, files are in dist"


### PR DESCRIPTION
I've updated build documentation for setting up the Windows development environment, added a bit to notarizing for macOS, and add a source package release section, including a script to generate source packages.