### PR TITLE
Fix autostop timer countdown string

### DIFF
--- a/share/locale/ca.json
+++ b/share/locale/ca.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "El temporitzador acaba a {}",
     "gui_receive_start_server": "Inicia en mode de recepció",
     "gui_receive_stop_server": "Atura el mode de recepció",
-    "gui_receive_stop_server_autostop_timer": "Atura el mode de recepció (queden {}s)",
+    "gui_receive_stop_server_autostop_timer": "Atura el mode de recepció (queden {})",
     "gui_receive_stop_server_autostop_timer_tooltip": "El temporitzador acaba a {}",
     "gui_copy_url": "Copia l'adreça",
     "gui_copy_hidservauth": "Copia el HidServAuth",

--- a/share/locale/cs.json
+++ b/share/locale/cs.json
@@ -77,6 +77,6 @@
     "gui_share_stop_server_autostop_timer": "Zastavit sdílení ({}s zbývá)",
     "gui_receive_start_server": "Spustit mód přijímání",
     "gui_receive_stop_server": "Zastavit přijímání",
-    "gui_receive_stop_server_autostop_timer": "Zastavit mód přijímání ({}s zbývá)",
+    "gui_receive_stop_server_autostop_timer": "Zastavit mód přijímání ({} zbývá)",
     "gui_copied_hidservauth_title": "Zkopírovaný HidServAuth token"
 }

--- a/share/locale/da.json
+++ b/share/locale/da.json
@@ -140,7 +140,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Timer med autostop slutter ved {}",
     "gui_receive_start_server": "Start modtagetilstand",
     "gui_receive_stop_server": "Stop modtagetilstand",
-    "gui_receive_stop_server_autostop_timer": "Stop modtagetilstand ({}s tilbage)",
+    "gui_receive_stop_server_autostop_timer": "Stop modtagetilstand ({} tilbage)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Timer med autostop slutter ved {}",
     "gui_no_downloads": "Ingen downloads endnu",
     "error_tor_protocol_error_unknown": "Der opstod en ukendt fejl med Tor",

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -19,7 +19,7 @@
     "gui_start_server_autostart_timer_tooltip": "Auto-start timer ends at {}",
     "gui_receive_start_server": "Start Receive Mode",
     "gui_receive_stop_server": "Stop Receive Mode",
-    "gui_receive_stop_server_autostop_timer": "Stop Receive Mode ({}s remaining)",
+    "gui_receive_stop_server_autostop_timer": "Stop Receive Mode ({} remaining)",
     "gui_copy_url": "Copy Address",
     "gui_copy_hidservauth": "Copy HidServAuth",
     "gui_canceled": "Canceled",

--- a/share/locale/es.json
+++ b/share/locale/es.json
@@ -64,7 +64,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "El temporizador de parada automática termina en {}",
     "gui_receive_start_server": "Iniciar el modo de recepción",
     "gui_receive_stop_server": "Detener el modo de recepción",
-    "gui_receive_stop_server_autostop_timer": "Detener el modo de recepción ({}s restantes)",
+    "gui_receive_stop_server_autostop_timer": "Detener el modo de recepción ({} restantes)",
     "gui_receive_stop_server_autostop_timer_tooltip": "El temporizador de parada automática termina en {}",
     "gui_copy_hidservauth": "Copiar HidServAuth",
     "gui_no_downloads": "Ninguna Descarga Todavía",

--- a/share/locale/fi.json
+++ b/share/locale/fi.json
@@ -39,7 +39,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Auto-stop ajastin loppuu {} jälkeen",
     "gui_receive_start_server": "Aloita vastaanotto tila",
     "gui_receive_stop_server": "Lopeta vastaanotto tila",
-    "gui_receive_stop_server_autostop_timer": "Lopeta vastaanotto tila ({}s jäljellä)",
+    "gui_receive_stop_server_autostop_timer": "Lopeta vastaanotto tila ({} jäljellä)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Auto-stop ajastin loppuu kello {}",
     "gui_copy_hidservauth": "Kopioi HidServAuth",
     "gui_copied_url_title": "Kopioi OnionShare osoite",

--- a/share/locale/fr.json
+++ b/share/locale/fr.json
@@ -148,7 +148,7 @@
     "help_receive": "Recevoir des partages au lieu de les envoyer",
     "gui_receive_start_server": "Démarrer le mode réception",
     "gui_receive_stop_server": "Arrêter le mode réception",
-    "gui_receive_stop_server_autostop_timer": "Arrêter le mode réception ({} s restantes)",
+    "gui_receive_stop_server_autostop_timer": "Arrêter le mode réception ({} restantes)",
     "gui_download_upload_progress_complete": "%p%, {0:s} écoulées.",
     "gui_download_upload_progress_starting": "{0:s}, %p% (estimation)",
     "gui_download_upload_progress_eta": "{0:s}, Fin : {1:s}, %p%",

--- a/share/locale/ga.json
+++ b/share/locale/ga.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Amadóir uathstoptha caite {}",
     "gui_receive_start_server": "Tosaigh an Mód Glactha",
     "gui_receive_stop_server": "Stop an Mód Glactha",
-    "gui_receive_stop_server_autostop_timer": "Stop an Mód Glactha ({}s fágtha)",
+    "gui_receive_stop_server_autostop_timer": "Stop an Mód Glactha ({} fágtha)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Amadóir uathstoptha caite {}",
     "gui_copy_url": "Cóipeáil an Seoladh",
     "gui_copy_hidservauth": "Cóipeáil HidServAuth",

--- a/share/locale/id.json
+++ b/share/locale/id.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "",
     "gui_receive_start_server": "Mulai Mode Menerima",
     "gui_receive_stop_server": "Menghentikan Mode Menerima",
-    "gui_receive_stop_server_autostop_timer": "Menghentikan Mode Menerima ({}d tersisa)",
+    "gui_receive_stop_server_autostop_timer": "Menghentikan Mode Menerima ({} tersisa)",
     "gui_receive_stop_server_autostop_timer_tooltip": "",
     "gui_copy_url": "Salin Alamat",
     "gui_copy_hidservauth": "Salin HidServAuth",

--- a/share/locale/is.json
+++ b/share/locale/is.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Sjálfvirk niðurtalning endar {}",
     "gui_receive_start_server": "Byrja í móttökuham",
     "gui_receive_stop_server": "Hætta í móttökuham",
-    "gui_receive_stop_server_autostop_timer": "Hætta í móttökuham ({}s eftir)",
+    "gui_receive_stop_server_autostop_timer": "Hætta í móttökuham ({} eftir)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Sjálfvirk niðurtalning endar {}",
     "gui_copy_url": "Afrita vistfang",
     "gui_copy_hidservauth": "Afrita HidServAuth",

--- a/share/locale/it.json
+++ b/share/locale/it.json
@@ -46,7 +46,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Il timer si arresterà tra {}",
     "gui_receive_start_server": "Inizia la ricezione",
     "gui_receive_stop_server": "Arresta la ricezione",
-    "gui_receive_stop_server_autostop_timer": "Interrompi la ricezione ({}s rimanenti)",
+    "gui_receive_stop_server_autostop_timer": "Interrompi la ricezione ({} rimanenti)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Il timer termina tra {}",
     "gui_copy_hidservauth": "Copia HidServAuth",
     "gui_no_downloads": "Ancora nessun Download",

--- a/share/locale/nb.json
+++ b/share/locale/nb.json
@@ -42,7 +42,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Tidsavbruddsuret går ut {}",
     "gui_receive_start_server": "Start mottaksmodus",
     "gui_receive_stop_server": "Stopp mottaksmodus",
-    "gui_receive_stop_server_autostop_timer": "Stopp mottaksmodus ({}s gjenstår)",
+    "gui_receive_stop_server_autostop_timer": "Stopp mottaksmodus ({} gjenstår)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Tidsavbruddsuret går ut {}",
     "gui_copy_url": "Kopier nettadresse",
     "gui_copy_hidservauth": "Kopier HidServAuth",

--- a/share/locale/nl.json
+++ b/share/locale/nl.json
@@ -112,7 +112,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Auto-stop timer eindigt bij {}",
     "gui_receive_start_server": "Start Ontvangstmodus",
     "gui_receive_stop_server": "Stop Ontvangstmodus",
-    "gui_receive_stop_server_autostop_timer": "Stop Ontvangstmodus ({}s resterend)",
+    "gui_receive_stop_server_autostop_timer": "Stop Ontvangstmodus ({} resterend)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Auto-stop timer stopt bij {}",
     "gui_no_downloads": "Nog Geen Downloads",
     "gui_copied_url_title": "Gekopieerd OnionShare Adres",

--- a/share/locale/pl.json
+++ b/share/locale/pl.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Czas upłynie za {}",
     "gui_receive_start_server": "Rozpocznij tryb odbierania",
     "gui_receive_stop_server": "Zatrzymaj tryb odbierania",
-    "gui_receive_stop_server_autostop_timer": "Zatrzymaj tryb odbierania (pozostało {}s)",
+    "gui_receive_stop_server_autostop_timer": "Zatrzymaj tryb odbierania (pozostało {})",
     "gui_receive_stop_server_autostop_timer_tooltip": "Czas upływa za {}",
     "gui_copy_url": "Kopiuj adres załącznika",
     "gui_copy_hidservauth": "Kopiuj HidServAuth",

--- a/share/locale/pt_BR.json
+++ b/share/locale/pt_BR.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "O cronômetro automático termina às",
     "gui_receive_start_server": "Modo Começar a Receber",
     "gui_receive_stop_server": "Modo Parar de Receber",
-    "gui_receive_stop_server_autostop_timer": "Modo Parar de Receber ({}segundos para terminar)",
+    "gui_receive_stop_server_autostop_timer": "Modo Parar de Receber ({} para terminar)",
     "gui_receive_stop_server_autostop_timer_tooltip": "O cronômetro automático termina às {}",
     "gui_copy_url": "Copiar endereço",
     "gui_copy_hidservauth": "Copiar HidServAuth",

--- a/share/locale/pt_PT.json
+++ b/share/locale/pt_PT.json
@@ -41,7 +41,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "O cronómetro automático de parar a partilha termina em {}",
     "gui_receive_start_server": "Começar modo de receber",
     "gui_receive_stop_server": "Parar modo de receber",
-    "gui_receive_stop_server_autostop_timer": "Parar modo de receber ({}s restantes)",
+    "gui_receive_stop_server_autostop_timer": "Parar modo de receber ({} restantes)",
     "gui_receive_stop_server_autostop_timer_tooltip": "O cronómetro automático de parar a partilha termina em {}",
     "gui_copy_url": "Copiar endereço",
     "gui_copy_hidservauth": "Copiar HidServAuth",

--- a/share/locale/ru.json
+++ b/share/locale/ru.json
@@ -64,7 +64,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Время таймера истекает в {}",
     "gui_receive_start_server": "Включить режим получения",
     "gui_receive_stop_server": "Выключить режим получения",
-    "gui_receive_stop_server_autostop_timer": "Выключить Режим Получения (осталось {}с)",
+    "gui_receive_stop_server_autostop_timer": "Выключить Режим Получения (осталось {})",
     "gui_receive_stop_server_autostop_timer_tooltip": "Время таймера истекает в {}",
     "gui_copy_hidservauth": "Скопировать строку HidServAuth",
     "gui_downloads": "История скачиваний",

--- a/share/locale/sv.json
+++ b/share/locale/sv.json
@@ -42,7 +42,7 @@
     "gui_share_stop_server_autostop_timer_tooltip": "Automatiska stopp-tidtagaren avslutar vid {}",
     "gui_receive_start_server": "Starta mottagarläge",
     "gui_receive_stop_server": "Avsluta Mottagarläge",
-    "gui_receive_stop_server_autostop_timer": "Avsluta Mottagarläge ({}s kvarstår)",
+    "gui_receive_stop_server_autostop_timer": "Avsluta Mottagarläge ({} kvarstår)",
     "gui_receive_stop_server_autostop_timer_tooltip": "Automatiska stopp-tidtagaren avslutar vid {}",
     "gui_copy_url": "Kopiera Adress",
     "gui_copy_hidservauth": "Kopiera HidServAuth",

--- a/share/locale/uk.json
+++ b/share/locale/uk.json
@@ -19,7 +19,7 @@
     "gui_start_server_autostart_timer_tooltip": "Таймеру автостарту спливає о {}",
     "gui_receive_start_server": "Розпочати Режим Отримання",
     "gui_receive_stop_server": "Зупинити Режим Отримання",
-    "gui_receive_stop_server_autostop_timer": "Зупинити Режим Отримання ({}с залишилось)",
+    "gui_receive_stop_server_autostop_timer": "Зупинити Режим Отримання ({} залишилось)",
     "gui_copy_url": "Копіювати Адресу",
     "gui_copy_hidservauth": "Скопіювати HidServAuth",
     "gui_canceled": "Скасовано",


### PR DESCRIPTION
We previously had 's' hardcoded into the autostop timer countdown string.

We then moved to a human friendly time but forgot to remove the 's'. So otherwise, the countdown looks like '1m, 40ss remaining' (double s)

I am being cheeky here and force updating as many translations that I can find which have dutifully included the extra `s` (or have adjusted it to the equivalent letter in the target language). But there might be others, particularly the asian languages that aren't formatting properly in my vim when I open them :(

It's only a minor string bug but it might be nice to add in prior to release.