### PR TITLE
Added python-flask-httpauth depend

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ Install the needed dependencies:
 For Debian-like distros:
 
 ```
-apt install -y python3-flask python3-stem python3-pyqt5 python3-crypto python3-socks python-nautilus tor obfs4proxy python3-pytest build-essential fakeroot python3-all python3-stdeb dh-python
+apt install -y python3-flask python3-stem python3-pyqt5 python3-crypto python3-socks python-nautilus tor obfs4proxy python3-pytest build-essential fakeroot python3-all python3-stdeb dh-python python-flask-httpauth 
 ```
 
 For Fedora-like distros:


### PR DESCRIPTION
added flask httpauth depend to the install instructions for debian.  Otherwise, this exception appears.

ImportError: No module named 'flask_httpauth'