### PR TITLE
DragonFly is *BSD; bringing back #716

### DIFF
--- a/onionshare/common.py
+++ b/onionshare/common.py
@@ -41,7 +41,7 @@ class Common(object):
 
         # The platform OnionShare is running on
         self.platform = platform.system()
-        if self.platform.endswith('BSD'):
+        if self.platform.endswith('BSD') or self.platform == 'DragonFly':
             self.platform = 'BSD'
 
         # The current version of OnionShare

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ data_files=[
         (os.path.join(sys.prefix, 'share/onionshare/static/img'), file_list('share/static/img')),
         (os.path.join(sys.prefix, 'share/onionshare/static/js'), file_list('share/static/js'))
     ]
-if platform.system() != 'OpenBSD':
+if not platform.system().endswith('BSD') and platform.system() != 'DragonFly':
     data_files.append(('/usr/share/nautilus-python/extensions/', ['install/scripts/onionshare-nautilus.py']))
 
 setup(


### PR DESCRIPTION
bringing back #716, in order to merge into right branch and keep standards for *BSD systems.