### PR TITLE
Move duplicate python3-flask-httpauth to the Fedora dependency list in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,13 +14,13 @@ Install the needed dependencies:
 For Debian-like distros:
 
 ```
-apt install -y python3-flask python3-flask-httpauth python3-stem python3-pyqt5 python3-crypto python3-socks python-nautilus tor obfs4proxy python3-pytest build-essential fakeroot python3-all python3-stdeb dh-python python3-flask-httpauth python3-distutils
+apt install -y python3-flask python3-stem python3-pyqt5 python3-crypto python3-socks python-nautilus tor obfs4proxy python3-pytest build-essential fakeroot python3-all python3-stdeb dh-python python3-flask-httpauth python3-distutils
 ```
 
 For Fedora-like distros:
 
 ```
-dnf install -y python3-flask python3-stem python3-qt5 python3-crypto python3-pysocks nautilus-python tor obfs4 python3-pytest rpm-build
+dnf install -y python3-flask python3-flask-httpauth python3-stem python3-qt5 python3-crypto python3-pysocks nautilus-python tor obfs4 python3-pytest rpm-build
 ```
 
 After that you can try both the CLI and the GUI version of OnionShare:


### PR DESCRIPTION
Commit afa91c9dcd11d9acef547d74d4656f1a1d004fa5 accidentally added python3-flask-httpauth twice to the Debian dependencies (it was already there for Debian). This moves it to the Fedora list.