### PR TITLE
Update localization for verison 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tags
 
 # virtualenv
 venv
+
+# other
+.vscode

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -64,7 +64,7 @@ class Settings(object):
         # Dictionary of available languages in this version of OnionShare,
         # mapped to the language name, in that language
         self.available_locales = {
-            'ar': 'العربية', # Arabic
+            "ar": "العربية",  # Arabic
             #'bn': 'বাংলা', # Bengali (commented out because not at 90% translation)
             "ca": "Català",  # Catalan
             "zh_Hant": "正體中文 (繁體)",  # Traditional Chinese
@@ -81,13 +81,13 @@ class Settings(object):
             "it": "Italiano",  # Italian
             "ja": "日本語",  # Japanese
             "nb": "Norsk Bokmål",  # Norwegian Bokmål
-            'fa': 'فارسی', # Persian
+            "fa": "فارسی",  # Persian
             "pl": "Polski",  # Polish
             "pt_BR": "Português (Brasil)",  # Portuguese Brazil
             "pt_PT": "Português (Portugal)",  # Portuguese Portugal
             "ro": "Română",  # Romanian
             "ru": "Русский",  # Russian
-            "sr_Latn": "Српски",  #  Serbian (latin)
+            "sr_Latn": "Srpska (latinica)",  #  Serbian (latin)
             "es": "Español",  # Spanish
             "sv": "Svenska",  # Swedish
             "te": "తెలుగు",  # Telugu

--- a/onionshare/settings.py
+++ b/onionshare/settings.py
@@ -64,13 +64,15 @@ class Settings(object):
         # Dictionary of available languages in this version of OnionShare,
         # mapped to the language name, in that language
         self.available_locales = {
+            'ar': 'العربية', # Arabic
             #'bn': 'বাংলা', # Bengali (commented out because not at 90% translation)
             "ca": "Català",  # Catalan
             "zh_Hant": "正體中文 (繁體)",  # Traditional Chinese
             "zh_Hans": "中文 (简体)",  # Simplified Chinese
             "da": "Dansk",  # Danish
+            "nl": "Nederlands",  # Dutch
             "en": "English",  # English
-            "fi": "Suomi",  # Finnish
+            # "fi": "Suomi",  # Finnish (commented out because not at 90% translation)
             "fr": "Français",  # French
             "de": "Deutsch",  # German
             "el": "Ελληνικά",  # Greek
@@ -79,11 +81,13 @@ class Settings(object):
             "it": "Italiano",  # Italian
             "ja": "日本語",  # Japanese
             "nb": "Norsk Bokmål",  # Norwegian Bokmål
-            #'fa': 'فارسی', # Persian (commented out because not at 90% translation)
+            'fa': 'فارسی', # Persian
             "pl": "Polski",  # Polish
             "pt_BR": "Português (Brasil)",  # Portuguese Brazil
             "pt_PT": "Português (Portugal)",  # Portuguese Portugal
+            "ro": "Română",  # Romanian
             "ru": "Русский",  # Russian
+            "sr_Latn": "Српски",  #  Serbian (latin)
             "es": "Español",  # Spanish
             "sv": "Svenska",  # Swedish
             "te": "తెలుగు",  # Telugu


### PR DESCRIPTION
This will resolve #1028.

We have new languages:

- Arabic
- Dutch
- Persian
- Romanian
- Serbian

And sadly we had to remove Finnish because it dropped below 90% translation (87.3%).

Before this is ready though, I need to confirm a few things:

- Is Arabic written as `العربية`?
- Is Romanian written as `Română`?
- Is Serbian (latin) written as `Српски`? (I assume I need to specify latin in there somewhere, but I'm not sure how...)

Finally, there is one more thing to deal with related to detecting the user's language. It's not the most critical, so it's ok if it doesn't make it into this release. Here's the list of languages we support now:

```python
# Dictionary of available languages in this version of OnionShare,
# mapped to the language name, in that language
self.available_locales = {
    'ar': 'العربية', # Arabic
    #'bn': 'বাংলা', # Bengali (commented out because not at 90% translation)
    "ca": "Català",  # Catalan
    "zh_Hant": "正體中文 (繁體)",  # Traditional Chinese
    "zh_Hans": "中文 (简体)",  # Simplified Chinese
    "da": "Dansk",  # Danish
    "nl": "Nederlands",  # Dutch
    "en": "English",  # English
    # "fi": "Suomi",  # Finnish (commented out because not at 90% translation)
    "fr": "Français",  # French
    "de": "Deutsch",  # German
    "el": "Ελληνικά",  # Greek
    "is": "Íslenska",  # Icelandic
    "ga": "Gaeilge",  # Irish
    "it": "Italiano",  # Italian
    "ja": "日本語",  # Japanese
    "nb": "Norsk Bokmål",  # Norwegian Bokmål
    'fa': 'فارسی', # Persian
    "pl": "Polski",  # Polish
    "pt_BR": "Português (Brasil)",  # Portuguese Brazil
    "pt_PT": "Português (Portugal)",  # Portuguese Portugal
    "ro": "Română",  # Romanian
    "ru": "Русский",  # Russian
    "sr_Latn": "Српски",  #  Serbian (latin)
    "es": "Español",  # Spanish
    "sv": "Svenska",  # Swedish
    "te": "తెలుగు",  # Telugu
    "tr": "Türkçe",  # Turkish
    "uk": "Українська",  # Ukrainian
}
```

Here is the code that tries to detect the language based on the user's operating system locale:

```python
# Choose the default locale based on the OS preference, and fall-back to English
if self._settings["locale"] is None:
    language_code, encoding = locale.getdefaultlocale()

    # Default to English
    if not language_code:
        language_code = "en_US"

    if language_code == "pt_PT" and language_code == "pt_BR":
        # Portuguese locales include country code
        default_locale = language_code
    else:
        # All other locales cut off the country code
        default_locale = language_code[:2]

    if default_locale not in self.available_locales:
        default_locale = "en"
    self._settings["locale"] = default_locale
```

The `self.available_locales` dictionary maps the 2-letter language code to the name of the language, except in a few cases. These include `zh_Hant`, `zh_Hans`, `pt_BR`, `pt_PT`, and `sr_Latn`. The code checks for auto-detecting the Portuguese locales, but it will never successfully detect the Chinese or Serbian locales right now. It would be good to do that, but I honestly don't know what `locale.getdefaultlocale()` returns when your computer is set to those locales.