### PR TITLE
Communicate a 405 error properly to the UI

### DIFF
--- a/onionshare/web/send_base_mode.py
+++ b/onionshare/web/send_base_mode.py
@@ -162,15 +162,17 @@ class SendBaseModeWeb:
         # Tell GUI the individual file started
         history_id = self.cur_history_id
         self.cur_history_id += 1
+
+        # Only GET requests are allowed, any other method should fail
+        if request.method != "GET":
+            return self.web.error405(history_id)
+
         self.web.add_request(
             self.web.REQUEST_INDIVIDUAL_FILE_STARTED,
             path,
             {"id": history_id, "filesize": filesize},
         )
 
-        # Only GET requests are allowed, any other method should fail
-        if request.method != "GET":
-            return self.web.error405()
 
         def generate():
             chunk_size = 102400  # 100kb

--- a/onionshare/web/web.py
+++ b/onionshare/web/web.py
@@ -266,7 +266,14 @@ class Web:
         )
         return self.add_security_headers(r)
 
-    def error405(self):
+    def error405(self, history_id):
+        self.add_request(
+            self.REQUEST_INDIVIDUAL_FILE_STARTED,
+            "{}".format(request.path),
+            {"id": history_id, "status_code": 405},
+        )
+
+        self.add_request(Web.REQUEST_OTHER, request.path)
         r = make_response(
             render_template("405.html", static_url_path=self.static_url_path), 405
         )


### PR DESCRIPTION
Fixes #1049 

We were sending a request back to the UI too early before processing the `error405()` logic. Additionally, the `error405` logic needed to send back the status code to properly render the information as a history item.

Note: this only works for HEAD and maybe OPTIONS requests. Flask is for some reason throwing its own 405 error (not our rendered template) on POST requests early, without the chance for our logic to fire. So POST requests will not show up in the UI. Couldn't find a fix.