### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/tests/test_onionshare_web.py
+++ b/tests/test_onionshare_web.py
@@ -71,7 +71,7 @@ def web_obj(common_obj, mode, num_files=0):
 class TestWeb:
     def test_share_mode(self, common_obj):
         web = web_obj(common_obj, "share", 3)
-        assert web.mode is "share"
+        assert web.mode == "share"
         with web.app.test_client() as c:
             # Load / without auth
             res = c.get("/")
@@ -127,7 +127,7 @@ class TestWeb:
 
     def test_receive_mode(self, common_obj):
         web = web_obj(common_obj, "receive")
-        assert web.mode is "receive"
+        assert web.mode == "receive"
 
         with web.app.test_client() as c:
             # Load / without auth


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior

The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead.