### PR TITLE
1064 tabs fixes

### DIFF
--- a/tests/gui_base_test.py
+++ b/tests/gui_base_test.py
@@ -80,7 +80,7 @@ class GuiBaseTest(unittest.TestCase):
 
     def verify_new_tab(self, tab):
         # Make sure the new tab widget is showing, and no mode has been started
-        QtTest.QTest.qWait(500)
+        QtTest.QTest.qWait(1000)
         self.assertTrue(tab.new_tab.isVisible())
         self.assertFalse(hasattr(tab, "share_mode"))
         self.assertFalse(hasattr(tab, "receive_mode"))
@@ -349,7 +349,7 @@ class GuiBaseTest(unittest.TestCase):
 
     def web_server_is_stopped(self, tab):
         """Test that the web server also stopped"""
-        QtTest.QTest.qWait(200)
+        QtTest.QTest.qWait(800)
 
         try:
             requests.get(f"http://127.0.0.1:{tab.app.port}/")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ class MyOnion:
         self.scheduled_key = None
 
     @staticmethod
-    def start_onion_service(self, await_publication=True, save_scheduled_key=False):
+    def start_onion_service(self, mode_settings_obj, await_publication=True, save_scheduled_key=False):
         return "test_service_id.onion"
 
 

--- a/tests/test_gui_share.py
+++ b/tests/test_gui_share.py
@@ -561,6 +561,11 @@ class TestShare(GuiBaseTest):
         Rate limit should be triggered
         """
         tab = self.new_share_tab()
+        def accept_dialog():
+            window = tab.common.gui.qtapp.activeWindow()
+            if window:
+                window.close()
+
         tab.get_mode().autostop_sharing_checkbox.click()
 
         self.run_all_common_setup_tests()
@@ -575,6 +580,11 @@ class TestShare(GuiBaseTest):
         Public mode should skip the rate limit
         """
         tab = self.new_share_tab()
+        def accept_dialog():
+            window = tab.common.gui.qtapp.activeWindow()
+            if window:
+                window.close()
+
         tab.get_mode().autostop_sharing_checkbox.click()
         tab.get_mode().mode_settings_widget.public_checkbox.click()
 


### PR DESCRIPTION
I got the CircleCI tests to succeed, with these changes... especially the slight increasing of the qWaits in the last commit, that seemed to be the clincher for the 'random' failures, which must relate to the speed of the VM running the test.

https://circleci.com/gh/mig5/onionshare/321

But I'm still a bit lost catching up on all the changes, so I didn't want to commit directly back to your branch.

Locally, I kept getting failures on the 'rate limit' tests, until I added those accept_dialog functions. I was getting a popup dialog about 'unable to create directory' in /tmp for some reason (I don't know why those appear on those tests), the accept dialog I guess closes the dialog, but feels like a bug in its own right that those dialogs appear.

