### PR TITLE
Made URL selectable by mouse and keyboard, commented out self.copy_ur…

### DIFF
--- a/onionshare_gui/server_status.py
+++ b/onionshare_gui/server_status.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import platform
 import textwrap
 from PyQt5 import QtCore, QtWidgets, QtGui
+from PyQt5.QtCore import Qt
 
 from onionshare import strings
 
@@ -152,6 +153,7 @@ class ServerStatus(QtWidgets.QWidget):
         self.url.setWordWrap(True)
         self.url.setMinimumSize(self.url.sizeHint())
         self.url.setStyleSheet(self.common.css["server_status_url"])
+        self.url.setTextInteractionFlags(Qt.TextSelectableByMouse | Qt.TextSelectableByKeyboard)
 
         self.copy_url_button = QtWidgets.QPushButton(strings._("gui_copy_url"))
         self.copy_url_button.setFlat(True)
@@ -483,7 +485,7 @@ class ServerStatus(QtWidgets.QWidget):
         The server has finished starting.
         """
         self.status = self.STATUS_STARTED
-        self.copy_url()
+        # self.copy_url()
         self.update()
         self.server_started_finished.emit()
 


### PR DESCRIPTION
…l() to prevent overwriting clipboard

The inability to select the URL for copying felt unintuitive to me. This makes the URL selectable via mouse and keyboard. I was also concerned that Onionshare was automatically copying its URL to the clipboard without warning the user that this was going to happen. It feels like this could overwrite something on the user's clipboard that perhaps they were not ready to overwrite.