### PR TITLE
Fix openSUSE misspelling

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -55,7 +55,7 @@ Create a .deb on Debian-like distros: `./install/build_deb.sh`
 
 Create a .rpm on Fedora-like distros: `./install/build_rpm.sh`
 
-For OpenSuSE: There are instructions for building [in the wiki](https://github.com/micahflee/onionshare/wiki/Linux-Distribution-Support#opensuse-leap-150).
+For openSUSE: There are instructions for building [in the wiki](https://github.com/micahflee/onionshare/wiki/Linux-Distribution-Support#opensuse-leap-150).
 
 For ArchLinux: There is a PKBUILD available [here](https://aur.archlinux.org/packages/onionshare/) that can be used to install OnionShare.
 


### PR DESCRIPTION
The correct spelling of openSUSE can be checked on https://en.opensuse.org/Portal:Distribution