### PR TITLE
auto-start/stop fixes

### DIFF
--- a/onionshare_gui/tab/mode/__init__.py
+++ b/onionshare_gui/tab/mode/__init__.py
@@ -138,7 +138,7 @@ class Mode(QtWidgets.QWidget):
         """
         # If this is a scheduled share, display the countdown til the share starts
         if self.server_status.status == ServerStatus.STATUS_WORKING:
-            if self.server_status.autostart_timer_datetime:
+            if self.settings.get("general", "autostart_timer"):
                 now = QtCore.QDateTime.currentDateTime()
                 if self.server_status.local_only:
                     seconds_remaining = now.secsTo(
@@ -227,13 +227,8 @@ class Mode(QtWidgets.QWidget):
         # Start the onion thread. If this share was scheduled for a future date,
         # the OnionThread will start and exit 'early' to obtain the port, password
         # and onion address, but it will not start the WebThread yet.
-        if self.server_status.autostart_timer_datetime:
+        if self.settings.get("general", "autostart_timer"):
             self.start_onion_thread(obtain_onion_early=True)
-        else:
-            self.start_onion_thread()
-
-        # If scheduling a share, delay starting the real share
-        if self.server_status.autostart_timer_datetime:
             self.common.log("Mode", "start_server", "Starting auto-start timer")
             self.startup_thread = AutoStartTimer(self)
             # Once the timer has finished, start the real share, with a WebThread
@@ -241,6 +236,8 @@ class Mode(QtWidgets.QWidget):
             self.startup_thread.error.connect(self.start_server_error)
             self.startup_thread.canceled = False
             self.startup_thread.start()
+        else:
+            self.start_onion_thread()
 
     def start_onion_thread(self, obtain_onion_early=False):
         self.common.log("Mode", "start_server", "Starting an onion thread")

--- a/onionshare_gui/tab/mode/mode_settings_widget.py
+++ b/onionshare_gui/tab/mode/mode_settings_widget.py
@@ -76,7 +76,10 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         self.autostart_timer_widget.setCurrentSection(
             QtWidgets.QDateTimeEdit.MinuteSection
         )
-        self.autostart_timer_widget.hide()
+        if self.settings.get("general", "autostart_timer"):
+            self.autostart_timer_widget.show()
+        else:
+            self.autostart_timer_widget.hide()
 
         # Autostart timer layout
         autostart_timer_layout = QtWidgets.QHBoxLayout()
@@ -104,7 +107,10 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         self.autostop_timer_widget.setCurrentSection(
             QtWidgets.QDateTimeEdit.MinuteSection
         )
-        self.autostop_timer_widget.hide()
+        if self.settings.get("general", "autostop_timer"):
+            self.autostop_timer_widget.show()
+        else:
+            self.autostop_timer_widget.hide()
 
         # Autostop timer layout
         autostop_timer_layout = QtWidgets.QHBoxLayout()

--- a/onionshare_gui/tab/server_status.py
+++ b/onionshare_gui/tab/server_status.py
@@ -269,7 +269,7 @@ class ServerStatus(QtWidgets.QWidget):
                     self.common.gui.css["server_status_button_working"]
                 )
                 self.server_button.setEnabled(True)
-                if self.autostart_timer_datetime:
+                if self.settings.get("general", "autostart_timer"):
                     self.server_button.setToolTip(
                         strings._("gui_start_server_autostart_timer_tooltip").format(
                             self.mode_settings_widget.autostart_timer_widget.dateTime().toString(
@@ -279,15 +279,6 @@ class ServerStatus(QtWidgets.QWidget):
                     )
                 else:
                     self.server_button.setText(strings._("gui_please_wait"))
-
-                if self.settings.get("general", "autostart_timer"):
-                    self.server_button.setToolTip(
-                        strings._("gui_start_server_autostart_timer_tooltip").format(
-                            self.mode_settings_widget.autostart_timer_widget.dateTime().toString(
-                                "h:mm AP, MMMM dd, yyyy"
-                            )
-                        )
-                    )
             else:
                 self.server_button.setStyleSheet(
                     self.common.gui.css["server_status_button_working"]

--- a/onionshare_gui/tab/tab.py
+++ b/onionshare_gui/tab/tab.py
@@ -287,7 +287,7 @@ class Tab(QtWidgets.QWidget):
                     strings._("gui_status_indicator_share_stopped")
                 )
             elif self.share_mode.server_status.status == ServerStatus.STATUS_WORKING:
-                if self.share_mode.server_status.autostart_timer_datetime:
+                if self.settings.get("general", "autostart_timer"):
                     self.set_server_status_indicator_working(
                         strings._("gui_status_indicator_share_scheduled")
                     )
@@ -320,7 +320,7 @@ class Tab(QtWidgets.QWidget):
                     strings._("gui_status_indicator_receive_stopped")
                 )
             elif self.receive_mode.server_status.status == ServerStatus.STATUS_WORKING:
-                if self.receive_mode.server_status.autostart_timer_datetime:
+                if self.settings.get("general", "autostart_timer"):
                     self.set_server_status_indicator_working(
                         strings._("gui_status_indicator_receive_scheduled")
                     )


### PR DESCRIPTION
Fixes logic that checks if auto-start timer setting is enabled, so that it checks real settings and not widget instantiation. 

This was the issue that resulted in shares still being 'scheduled' even after the auto-start setting had been unchecked. This was also causing the knock-on effect of 'ADD_ONION' collision errors (because OnionShare was trying to schedule a share that it shouldn't, resulting in a duplicate attempt to register the service id)

Also, I noticed that if the timers (both autostart and autostop) were enabled in settings, and settings were persistent, then on startup of OnionShare, the setting would be checked, but the dateTime() widget was not shown. The setting would have to be disabled and then re-enabled to activate the dateTime widget. This was just because we explicitly `hide()` the widget on startup, whereas in fact we should check if the setting was enabled first.
