### PR TITLE
#1095 Fix crash for shares larger than 2GB. #1089 add ETA/bytes uploaded in progress bar of ReceiveMode items

### DIFF
--- a/onionshare_gui/tab/mode/history.py
+++ b/onionshare_gui/tab/mode/history.py
@@ -119,7 +119,7 @@ class ShareHistoryItem(HistoryItem):
         self.progress_bar.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.progress_bar.setAlignment(QtCore.Qt.AlignHCenter)
         self.progress_bar.setMinimum(0)
-        self.progress_bar.setMaximum(total_bytes)
+        self.progress_bar.setMaximum(total_bytes / 1024)
         self.progress_bar.setValue(0)
         self.progress_bar.setStyleSheet(
             self.common.gui.css["downloads_uploads_progress_bar"]
@@ -138,8 +138,8 @@ class ShareHistoryItem(HistoryItem):
     def update(self, downloaded_bytes):
         self.downloaded_bytes = downloaded_bytes
 
-        self.progress_bar.setValue(downloaded_bytes)
-        if downloaded_bytes == self.progress_bar.total_bytes:
+        self.progress_bar.setValue(downloaded_bytes / 1024)
+        if (downloaded_bytes / 1024) == (self.progress_bar.total_bytes / 1024):
             pb_fmt = strings._("gui_all_modes_progress_complete").format(
                 self.common.format_seconds(time.time() - self.started)
             )
@@ -322,8 +322,8 @@ class ReceiveHistoryItem(HistoryItem):
                 total_uploaded_bytes += data["progress"][filename]["uploaded_bytes"]
 
             # Update the progress bar
-            self.progress_bar.setMaximum(self.content_length)
-            self.progress_bar.setValue(total_uploaded_bytes)
+            self.progress_bar.setMaximum(self.content_length / 1024)
+            self.progress_bar.setValue(total_uploaded_bytes / 1024)
 
             elapsed = datetime.now() - self.started
             if elapsed.seconds < 10:
@@ -338,6 +338,8 @@ class ReceiveHistoryItem(HistoryItem):
                     self.common.human_readable_filesize(total_uploaded_bytes),
                     estimated_time_remaining,
                 )
+
+            self.progress_bar.setFormat(pb_fmt)
 
             # Using list(progress) to avoid "RuntimeError: dictionary changed size during iteration"
             for filename in list(data["progress"]):
@@ -461,7 +463,7 @@ class IndividualFileHistoryItem(HistoryItem):
         self.downloaded_bytes = downloaded_bytes
 
         self.progress_bar.setValue(downloaded_bytes)
-        if downloaded_bytes == self.progress_bar.total_bytes:
+        if (downloaded_bytes / 1024 ) == (self.progress_bar.total_bytes / 1024):
             self.status_code_label.setText("200")
             self.status_code_label.setStyleSheet(
                 self.common.gui.css["history_individual_file_status_code_label_2xx"]

--- a/onionshare_gui/tab/mode/history.py
+++ b/onionshare_gui/tab/mode/history.py
@@ -453,7 +453,7 @@ class IndividualFileHistoryItem(HistoryItem):
         else:
             self.total_bytes = data["filesize"]
             self.progress_bar.setMinimum(0)
-            self.progress_bar.setMaximum(data["filesize"])
+            self.progress_bar.setMaximum(data["filesize"] / 1024)
             self.progress_bar.total_bytes = data["filesize"]
 
         # Start at 0
@@ -462,7 +462,7 @@ class IndividualFileHistoryItem(HistoryItem):
     def update(self, downloaded_bytes):
         self.downloaded_bytes = downloaded_bytes
 
-        self.progress_bar.setValue(downloaded_bytes)
+        self.progress_bar.setValue(downloaded_bytes / 1024)
         if (downloaded_bytes / 1024 ) == (self.progress_bar.total_bytes / 1024):
             self.status_code_label.setText("200")
             self.status_code_label.setStyleSheet(


### PR DESCRIPTION
Fixes #1089 
Fixes #1095 

The progress bar crash in #1095 has something to do with 32 bit integers in C/Python (I don't quite understand it) - a 2GB file, expressed in bytes, exceeded that integer and caused the crash. 

I copied the fix from the other open source project mentioned in that ticket, and it seems to work.

See also https://www.networkworld.com/article/3010974/whats-so-special-about-2147483648.html