### PR TITLE
Fail early if any of the tests fail, rather than continue and possibly exit 0

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,7 +20,7 @@ do
 	shift
 done
 
-pytest $PARAMS -vvv ./tests/test_cli*.py
+pytest $PARAMS -vvv ./tests/test_cli*.py || exit 1
 for filename in ./tests/test_gui_*.py; do
-	pytest $PARAMS -vvv --no-qt-log $filename
+	pytest $PARAMS -vvv --no-qt-log $filename || exit 1
 done


### PR DESCRIPTION
I was watching some tests run, and some failed at https://circleci.com/gh/mig5/onionshare/365?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

In this case it was a transient error probably only affecting that one virtual environment. However, the overall tests ended up reporting a success globally, and so a green tick to Github too, which I did not expect.

That's because the test script iterates over each .py file individually and runs pytest against it, but if one fails, it will happily keep going on the others, and if the last one succeeds, it'll return success.

This change makes it `exit 1` as soon as a failure happens. It might mean more errors on transient CircleCI build issues, but we don't want to risk missing any *real* test failures accidentally.

I guess `set -e` would achieve the same thing, feel free to close and do that if it suits your style more.