### PR TITLE
#1126 update the status bar each time the active tab is changed

### DIFF
--- a/onionshare_gui/tab_widget.py
+++ b/onionshare_gui/tab_widget.py
@@ -60,6 +60,7 @@ class TabWidget(QtWidgets.QTabWidget):
         # Use a custom tab bar
         tab_bar = TabBar()
         tab_bar.move_new_tab_button.connect(self.move_new_tab_button)
+        tab_bar.currentChanged.connect(self.tab_changed)
         self.setTabBar(tab_bar)
 
         # Set up the tab widget
@@ -107,6 +108,24 @@ class TabWidget(QtWidgets.QTabWidget):
 
         self.new_tab_button.move(pos)
         self.new_tab_button.raise_()
+
+    def tab_changed(self):
+        # Active tab was changed
+        tab_id = self.currentIndex()
+        self.common.log("TabWidget", "tab_changed", f"Tab was changed to {tab_id}")
+        try:
+            mode = self.tabs[tab_id].get_mode()
+            if mode:
+                # Update the server status indicator to reflect that of the current tab
+                self.tabs[tab_id].update_server_status_indicator()
+            else:
+                # If this tab doesn't have a mode set yet, blank the server status indicator
+                self.status_bar.server_status_image_label.clear()
+                self.status_bar.server_status_label.clear()
+        except KeyError:
+            # When all current tabs are closed, index briefly drops to -1 before resetting to 0
+            # which will otherwise trigger a KeyError on tab.get_mode() above.
+            pass
 
     def new_tab_clicked(self):
         # Create a new tab

--- a/tests/test_gui_tabs.py
+++ b/tests/test_gui_tabs.py
@@ -138,18 +138,21 @@ class TestTabs(GuiBaseTest):
         self.gui.tabs.widget(1).share_button.click()
         self.assertFalse(self.gui.tabs.widget(1).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(1).share_mode.isVisible())
+        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to share')
 
         # New tab, receive files
         self.gui.tabs.new_tab_button.click()
         self.gui.tabs.widget(2).receive_button.click()
         self.assertFalse(self.gui.tabs.widget(2).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(2).receive_mode.isVisible())
+        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to receive')
 
         # New tab, publish website
         self.gui.tabs.new_tab_button.click()
         self.gui.tabs.widget(3).website_button.click()
         self.assertFalse(self.gui.tabs.widget(3).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(3).website_mode.isVisible())
+        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to share')
 
         # Close tabs
         self.gui.tabs.tabBar().tabButton(0, QtWidgets.QTabBar.RightSide).click()


### PR DESCRIPTION
Fixes #1126 ! We now connect to the tab change signal and update the status bar to reflect the status of the current mode (or clear it if there is no mode set yet in the new tab).