### PR TITLE
Set the server status indicator to 'Scheduled' when in Website Mode and autostart timer is in use, to match the other modes

### DIFF
--- a/onionshare_gui/tab/tab.py
+++ b/onionshare_gui/tab/tab.py
@@ -306,9 +306,14 @@ class Tab(QtWidgets.QWidget):
                     strings._("gui_status_indicator_share_stopped")
                 )
             elif self.website_mode.server_status.status == ServerStatus.STATUS_WORKING:
-                self.set_server_status_indicator_working(
-                    strings._("gui_status_indicator_share_working")
-                )
+                if self.website_mode.server_status.autostart_timer_datetime:
+                    self.set_server_status_indicator_working(
+                        strings._("gui_status_indicator_share_scheduled")
+                    )
+                else:
+                    self.set_server_status_indicator_working(
+                        strings._("gui_status_indicator_share_working")
+                    )
             elif self.website_mode.server_status.status == ServerStatus.STATUS_STARTED:
                 self.set_server_status_indicator_started(
                     strings._("gui_status_indicator_share_started")


### PR DESCRIPTION
Noticed a scheduled Website Mode share didn't show 'Scheduled' when using autostart mode.