### PR TITLE
Fix forced persistence

### DIFF
--- a/onionshare_gui/tab/mode/mode_settings_widget.py
+++ b/onionshare_gui/tab/mode/mode_settings_widget.py
@@ -209,8 +209,11 @@ class ModeSettingsWidget(QtWidgets.QWidget):
             self.tab.tab_id, self.persistent_checkbox.isChecked()
         )
 
-        # If disabling persistence, delete the file from disk
+        # If disabling persistence, delete the file from disk and remove any existing onion address details from settings
         if not self.persistent_checkbox.isChecked():
+            self.settings.set("onion", "password", "")
+            self.settings.set("onion", "private_key", "")
+            self.settings.set("onion", "hidservauth_string", "")
             self.settings.delete()
 
     def public_checkbox_clicked(self):

--- a/onionshare_gui/tab/server_status.py
+++ b/onionshare_gui/tab/server_status.py
@@ -243,6 +243,7 @@ class ServerStatus(QtWidgets.QWidget):
             self.url.hide()
             self.copy_url_button.hide()
             self.copy_hidservauth_button.hide()
+            self.show_url_qr_code_button.hide()
 
             self.mode_settings_widget.update_ui()
 

--- a/onionshare_gui/tab/server_status.py
+++ b/onionshare_gui/tab/server_status.py
@@ -247,6 +247,13 @@ class ServerStatus(QtWidgets.QWidget):
 
             self.mode_settings_widget.update_ui()
 
+        if self.status == self.STATUS_STOPPED and not self.settings.get("persistent", "enabled"):
+            # Unset any previous onion address or passwords so they don't get re-used.
+            # Persistent mode will still force these through if set.
+            self.settings.set("onion", "password", "")
+            self.settings.set("onion", "private_key", "")
+            self.settings.set("onion", "hidservauth_string", "")
+
         # Button
         if (
             self.mode == self.common.gui.MODE_SHARE

--- a/share/locale/en.json
+++ b/share/locale/en.json
@@ -29,7 +29,7 @@
     "gui_copied_url": "OnionShare address copied to clipboard",
     "gui_copied_hidservauth_title": "Copied HidServAuth",
     "gui_copied_hidservauth": "HidServAuth line copied to clipboard",
-    "gui_show_url_qr_code": "Show QR code",
+    "gui_show_url_qr_code": "Show QR Code",
     "gui_qr_code_dialog_title": "OnionShare QR Code",
     "gui_qr_code_description": "Scan this QR code with a QR reader, such as the camera on your phone, in order to more easily share the OnionShare address with someone.",
     "gui_waiting_to_start": "Scheduled to start in {}. Click to cancel.",

--- a/tests/gui_base_test.py
+++ b/tests/gui_base_test.py
@@ -358,6 +358,11 @@ class GuiBaseTest(unittest.TestCase):
         ):
             tab.get_mode().server_status.server_button.click()
         self.assertEqual(tab.get_mode().server_status.status, 0)
+        self.assertFalse(tab.get_mode().server_status.show_url_qr_code_button.isVisible())
+        self.assertFalse(tab.get_mode().server_status.copy_url_button.isVisible())
+        self.assertFalse(tab.get_mode().server_status.url.isVisible())
+        self.assertFalse(tab.get_mode().server_status.url_description.isVisible())
+        self.assertFalse(tab.get_mode().server_status.copy_hidservauth_button.isVisible())
 
     def web_server_is_stopped(self, tab):
         """Test that the web server also stopped"""


### PR DESCRIPTION
This 'fixes' #1145 , however it looks to me like this may have been a deliberate change on your part?

76d109747e7caa861ee1a05e70334679d1942b04

> Move private_key, hidservauth_string, and password from "persistent" mode settings to "onion" mode settings; and make it so the onion settings are always saved in each tab, even if the tab is not persistent, so if you stop and start a service in the same tab it has the same onion address and password

This to me sounds like every tab is persistent during runtime. If you really wanted it that way then feel free to reject this. It felt like a bug to me, in that I expect onion addresses and related settings (auth password etc) to be totally ephemeral unless I enable persistent mode, but maybe you figured that's not what the average user expects.