### PR TITLE
Make GUI test suite run in Windows and macOS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -115,7 +115,7 @@ Download and install Python 3.7.4 from https://www.python.org/downloads/release/
 
 You may also need to run the command `/Applications/Python\ 3.7/Install\ Certificates.command` to update Python 3.6's internal certificate store. Otherwise, you may find that fetching the Tor Browser .dmg file fails later due to a certificate validation error.
 
-Install Qt 5.13.1 for macOS from https://www.qt.io/offline-installers. I downloaded `qt-opensource-mac-x64-5.13.1.dmg`. In the installer, you can skip making an account, and all you need is `Qt` > `Qt 5.13.1` > `macOS`.
+Install Qt 5.14.0 for macOS from https://www.qt.io/offline-installers. I downloaded `qt-opensource-mac-x64-5.14.0.dmg`. In the installer, you can skip making an account, and all you need is `Qt` > `Qt 5.14.0` > `macOS`.
 
 If you don't have it already, install poetry (`pip3 install --user poetry`). Then install dependencies:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -150,9 +150,11 @@ Now you should have `dist/OnionShare.pkg`.
 
 ### Setting up your dev environment
 
+These instructions include adding folders to the path in Windows. To do this, go to Start and type "advanced system settings", and open "View advanced system settings" in the Control Panel. Click Environment Variables. Under "System variables" double-click on Path. From there you can add and remove folders that are available in the PATH.
+
 Download Python 3.7.4, 32-bit (x86) from https://www.python.org/downloads/release/python-374/. I downloaded `python-3.7.4.exe`. When installing it, make sure to check the "Add Python 3.7 to PATH" checkbox on the first page of the installer.
 
-Install the Qt 5.13.1 from https://www.qt.io/offline-installers. I downloaded `qt-opensource-windows-x86-5.13.1.exe`. In the installer, you can skip making an account, and all you need `Qt` > `Qt 5.13.1` > `MSVC 2017 32-bit`.
+Install the Qt 5.14.0 from https://www.qt.io/offline-installers. I downloaded `qt-opensource-windows-x86-5.14.0.exe`. In the installer, you can skip making an account, and all you need `Qt` > `Qt 5.14.0` > `MSVC 2017 32-bit`.
 
 Install [poetry](https://python-poetry.org/). Open PowerShell, and run:
 
@@ -160,7 +162,7 @@ Install [poetry](https://python-poetry.org/). Open PowerShell, and run:
 (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python
 ```
 
-And add `%USERPROFILE%\.poetry\bin` to your path. Then open a command prompt and cd to the `dangerzone` folder, and install the poetry dependencies:
+Then open a Command Prompt and cd to the `onionshare` folder, and install the poetry dependencies:
 
 ```
 poetry install
@@ -174,8 +176,6 @@ poetry run python dev_scripts\onionshare-gui
 ```
 
 #### If you want to build a .exe
-
-These instructions include adding folders to the path in Windows. To do this, go to Start and type "advanced system settings", and open "View advanced system settings" in the Control Panel. Click Environment Variables. Under "System variables" double-click on Path. From there you can add and remove folders that are available in the PATH.
 
 Download and install 7-Zip from http://www.7-zip.org/download.html. I downloaded `7z1900.exe`.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -264,6 +264,8 @@ This will prompt you to codesign three binaries and execute one unsigned binary.
 
 # Running tests
 
+## Tests in macOS and Linux
+
 OnionShare includes PyTest unit tests. To run tests, you can run `pytest` against the `tests/` directory.
 
 ```sh
@@ -276,18 +278,18 @@ You can run GUI tests like this:
 poetry run ./tests/run.sh --rungui
 ```
 
-If you would like to also run the GUI unit tests in 'tor' mode, start Tor Browser in the background, then run:
-
-```sh
-poetry run ./tests/run.sh --rungui --runtor
-```
-
-Keep in mind that the Tor tests take a lot longer to run than local mode, but they are also more comprehensive.
-
-You can also choose to wrap the tests in `xvfb-run` so that a ton of OnionShare windows don't pop up on your desktop (you may need to install the `xorg-x11-server-Xvfb` package), like this:
+If you're using Linux, you can also choose to wrap the tests in `xvfb-run` so that a ton of OnionShare windows don't pop up on your desktop (you may need to install the `xorg-x11-server-Xvfb` package), like this:
 
 ```sh
 xvfb-run poetry run ./tests/run.sh --rungui
+```
+
+## Tests in Windows
+
+You can run this Windows batch script to run all of the CLI and GUI tests.
+
+```
+poetry run tests\run.bat
 ```
 
 # Making releases

--- a/onionshare/mode_settings.py
+++ b/onionshare/mode_settings.py
@@ -18,8 +18,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
-import pwd
 import json
+import platform
+
+if platform.system() == "Darwin":
+    import pwd
 
 
 class ModeSettings:

--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -665,15 +665,16 @@ class Onion(object):
         Stop a specific onion service
         """
         onion_host = mode_settings.get("general", "service_id")
-        self.common.log("Onion", "stop_onion_service", f"onion host: {onion_host}")
-        try:
-            self.c.remove_ephemeral_hidden_service(
-                mode_settings.get("general", "service_id")
-            )
-        except:
-            self.common.log(
-                "Onion", "stop_onion_service", f"failed to remove {onion_host}"
-            )
+        if onion_host:
+            self.common.log("Onion", "stop_onion_service", f"onion host: {onion_host}")
+            try:
+                self.c.remove_ephemeral_hidden_service(
+                    mode_settings.get("general", "service_id")
+                )
+            except:
+                self.common.log(
+                    "Onion", "stop_onion_service", f"failed to remove {onion_host}"
+                )
 
     def cleanup(self, stop_tor=True):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,9 +98,10 @@ def temp_file_1024_delete(temp_dir):
     The temporary file will be deleted after fixture usage.
     """
 
-    with tempfile.NamedTemporaryFile(dir=temp_dir) as tmp_file:
+    with tempfile.NamedTemporaryFile(dir=temp_dir, delete=False) as tmp_file:
         tmp_file.write(b"*" * 1024)
         tmp_file.flush()
+        tmp_file.close()
         yield tmp_file.name
 
 

--- a/tests/gui_base_test.py
+++ b/tests/gui_base_test.py
@@ -8,6 +8,7 @@ import shutil
 import base64
 import tempfile
 import secrets
+import platform
 
 from PyQt5 import QtCore, QtTest, QtWidgets
 
@@ -275,9 +276,17 @@ class GuiBaseTest(unittest.TestCase):
 
     def add_button_visible(self, tab):
         """Test that the add button should be visible"""
-        self.assertTrue(
-            tab.get_mode().server_status.file_selection.add_button.isVisible()
-        )
+        if platform.system() == "Darwin":
+            self.assertTrue(
+                tab.get_mode().server_status.file_selection.add_files_button.isVisible()
+            )
+            self.assertTrue(
+                tab.get_mode().server_status.file_selection.add_folder_button.isVisible()
+            )
+        else:
+            self.assertTrue(
+                tab.get_mode().server_status.file_selection.add_button.isVisible()
+            )
 
     def url_description_shown(self, tab):
         """Test that the URL label is showing"""
@@ -299,7 +308,10 @@ class GuiBaseTest(unittest.TestCase):
 
     def have_show_qr_code_button(self, tab):
         """Test that the Show QR Code URL button is shown and that it loads a QR Code Dialog"""
-        self.assertTrue(tab.get_mode().server_status.show_url_qr_code_button.isVisible())
+        self.assertTrue(
+            tab.get_mode().server_status.show_url_qr_code_button.isVisible()
+        )
+
         def accept_dialog():
             window = tab.common.gui.qtapp.activeWindow()
             if window:
@@ -358,11 +370,15 @@ class GuiBaseTest(unittest.TestCase):
         ):
             tab.get_mode().server_status.server_button.click()
         self.assertEqual(tab.get_mode().server_status.status, 0)
-        self.assertFalse(tab.get_mode().server_status.show_url_qr_code_button.isVisible())
+        self.assertFalse(
+            tab.get_mode().server_status.show_url_qr_code_button.isVisible()
+        )
         self.assertFalse(tab.get_mode().server_status.copy_url_button.isVisible())
         self.assertFalse(tab.get_mode().server_status.url.isVisible())
         self.assertFalse(tab.get_mode().server_status.url_description.isVisible())
-        self.assertFalse(tab.get_mode().server_status.copy_hidservauth_button.isVisible())
+        self.assertFalse(
+            tab.get_mode().server_status.copy_hidservauth_button.isVisible()
+        )
 
     def web_server_is_stopped(self, tab):
         """Test that the web server also stopped"""
@@ -406,9 +422,17 @@ class GuiBaseTest(unittest.TestCase):
 
     def add_remove_buttons_hidden(self, tab):
         """Test that the add and remove buttons are hidden when the server starts"""
-        self.assertFalse(
-            tab.get_mode().server_status.file_selection.add_button.isVisible()
-        )
+        if platform.system() == "Darwin":
+            self.assertFalse(
+                tab.get_mode().server_status.file_selection.add_files_button.isVisible()
+            )
+            self.assertFalse(
+                tab.get_mode().server_status.file_selection.add_folder_button.isVisible()
+            )
+        else:
+            self.assertFalse(
+                tab.get_mode().server_status.file_selection.add_button.isVisible()
+            )
         self.assertFalse(
             tab.get_mode().server_status.file_selection.remove_button.isVisible()
         )

--- a/tests/gui_base_test.py
+++ b/tests/gui_base_test.py
@@ -87,6 +87,7 @@ class GuiBaseTest(unittest.TestCase):
         self.assertFalse(hasattr(tab, "share_mode"))
         self.assertFalse(hasattr(tab, "receive_mode"))
         self.assertFalse(hasattr(tab, "website_mode"))
+        self.assertFalse(hasattr(tab, "chat_mode"))
 
     def new_share_tab(self):
         tab = self.gui.tabs.widget(0)

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -1,0 +1,9 @@
+pytest -vvv tests\test_cli.py
+pytest -vvv tests\test_cli_common.py
+pytest -vvv tests\test_cli_settings.py
+pytest -vvv tests\test_cli_strings.py
+pytest -vvv tests\test_cli_web.py
+pytest -vvv --rungui tests\test_gui_tabs.py
+pytest -vvv --rungui tests\test_gui_share.py
+pytest -vvv --rungui tests\test_gui_receive.py
+pytest -vvv --rungui tests\test_gui_website.py

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -235,8 +235,14 @@ class TestGetTorPaths:
         ) = common_obj.get_tor_paths()
 
         assert os.path.basename(tor_path) == "tor"
-        assert tor_geo_ip_file_path == "/usr/share/tor/geoip"
-        assert tor_geo_ipv6_file_path == "/usr/share/tor/geoip6"
+        assert (
+            tor_geo_ip_file_path == "/usr/share/tor/geoip"
+            or tor_geo_ip_file_path == "/usr/local/share/tor/geoip"
+        )
+        assert (
+            tor_geo_ipv6_file_path == "/usr/share/tor/geoip6"
+            or tor_geo_ipv6_file_path == "/usr/local/share/tor/geoip6"
+        )
 
     # @pytest.mark.skipif(sys.platform != 'Windows', reason='requires Windows') ?
     def test_get_tor_paths_windows(self, platform_windows, common_obj, sys_frozen):

--- a/tests/test_cli_settings.py
+++ b/tests/test_cli_settings.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import json
 import os
 import tempfile
+import sys
 
 import pytest
 
@@ -135,16 +136,25 @@ class TestSettings:
         settings_obj.set("socks_port", "NON_INTEGER")
         assert settings_obj._settings["socks_port"] == 9050
 
+    @pytest.mark.skipif(sys.platform != "Darwin", reason="requires Darwin")
     def test_filename_darwin(self, monkeypatch, platform_darwin):
         obj = settings.Settings(common.Common())
         assert obj.filename == os.path.expanduser(
             "~/Library/Application Support/OnionShare-testdata/onionshare.json"
         )
 
+    @pytest.mark.skipif(sys.platform != "Linux", reason="requires Linux")
     def test_filename_linux(self, monkeypatch, platform_linux):
         obj = settings.Settings(common.Common())
         assert obj.filename == os.path.expanduser(
             "~/.config/onionshare-testdata/onionshare.json"
+        )
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
+    def test_filename_windows(self, monkeypatch, platform_windows):
+        obj = settings.Settings(common.Common())
+        assert obj.filename == os.path.expanduser(
+            "~\\AppData\\Roaming\\OnionShare-testdata\\onionshare.json"
         )
 
     def test_set_custom_bridge(self, settings_obj):

--- a/tests/test_cli_web.py
+++ b/tests/test_cli_web.py
@@ -93,7 +93,10 @@ class TestWeb:
             res = c.get("/download", headers=self._make_auth_headers(web.password))
             res.get_data()
             assert res.status_code == 200
-            assert res.mimetype == "application/zip"
+            assert (
+                res.mimetype == "application/zip"
+                or res.mimetype == "application/x-zip-compressed"
+            )
 
     def test_share_mode_autostop_sharing_on(self, temp_dir, common_obj, temp_file_1024):
         web = web_obj(temp_dir, common_obj, "share", 3)
@@ -106,11 +109,16 @@ class TestWeb:
             res = c.get("/download", headers=self._make_auth_headers(web.password))
             res.get_data()
             assert res.status_code == 200
-            assert res.mimetype == "application/zip"
+            assert (
+                res.mimetype == "application/zip"
+                or res.mimetype == "application/x-zip-compressed"
+            )
 
             assert web.running == False
 
-    def test_share_mode_autostop_sharing_off(self, temp_dir, common_obj, temp_file_1024):
+    def test_share_mode_autostop_sharing_off(
+        self, temp_dir, common_obj, temp_file_1024
+    ):
         web = web_obj(temp_dir, common_obj, "share", 3)
         web.settings.set("share", "autostop_sharing", False)
 
@@ -121,7 +129,10 @@ class TestWeb:
             res = c.get("/download", headers=self._make_auth_headers(web.password))
             res.get_data()
             assert res.status_code == 200
-            assert res.mimetype == "application/zip"
+            assert (
+                res.mimetype == "application/zip"
+                or res.mimetype == "application/x-zip-compressed"
+            )
             assert web.running == True
 
     def test_receive_mode(self, temp_dir, common_obj):

--- a/tests/test_gui_receive.py
+++ b/tests/test_gui_receive.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import requests
 import shutil
+import sys
 from datetime import datetime, timedelta
 
 from PyQt5 import QtCore, QtTest
@@ -213,6 +214,7 @@ class TestReceive(GuiBaseTest):
         self.close_all_tabs()
 
     @pytest.mark.gui
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have chmod")
     def test_upload_non_writable_dir(self):
         """
         Test uploading files to a non-writable directory
@@ -237,6 +239,7 @@ class TestReceive(GuiBaseTest):
         self.close_all_tabs()
 
     @pytest.mark.gui
+    @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have chmod")
     def test_public_upload_non_writable_dir(self):
         """
         Test uploading files to a non-writable directory in public mode

--- a/tests/test_gui_share.py
+++ b/tests/test_gui_share.py
@@ -83,13 +83,13 @@ class TestShare(GuiBaseTest):
                 ),
             )
 
-        tmp_file = tempfile.NamedTemporaryFile()
-        with open(tmp_file.name, "wb") as f:
-            f.write(r.content)
+        tmp_file = tempfile.NamedTemporaryFile("wb", delete=False)
+        tmp_file.write(r.content)
+        tmp_file.close()
 
-        zip = zipfile.ZipFile(tmp_file.name)
+        z = zipfile.ZipFile(tmp_file.name)
         QtTest.QTest.qWait(50)
-        self.assertEqual("onionshare", zip.read("test.txt").decode("utf-8"))
+        self.assertEqual("onionshare", z.read("test.txt").decode("utf-8"))
 
         QtTest.QTest.qWait(500)
 
@@ -135,9 +135,8 @@ class TestShare(GuiBaseTest):
                     ),
                 )
 
-            tmp_file = tempfile.NamedTemporaryFile()
-            with open(tmp_file.name, "wb") as f:
-                f.write(r.content)
+            tmp_file = tempfile.NamedTemporaryFile("wb")
+            tmp_file.write(r.content)
 
             with open(tmp_file.name, "r") as f:
                 self.assertEqual("onionshare", f.read())
@@ -207,7 +206,10 @@ class TestShare(GuiBaseTest):
         QtTest.QTest.mouseRelease(
             tab.get_mode().server_status.server_button, QtCore.Qt.LeftButton
         )
-        self.assertEqual(tab.get_mode().server_status.status, 0)
+        self.assertEqual(
+            tab.get_mode().server_status.status,
+            tab.get_mode().server_status.STATUS_STOPPED,
+        )
         self.server_is_stopped(tab)
         self.web_server_is_stopped(tab)
 

--- a/tests/test_gui_share.py
+++ b/tests/test_gui_share.py
@@ -199,6 +199,7 @@ class TestShare(GuiBaseTest):
         self.add_remove_buttons_hidden(tab)
         self.mode_settings_widget_is_hidden(tab)
         self.set_autostart_timer(tab, 10)
+        QtTest.QTest.qWait(500)
         QtTest.QTest.mousePress(
             tab.get_mode().server_status.server_button, QtCore.Qt.LeftButton
         )
@@ -206,6 +207,7 @@ class TestShare(GuiBaseTest):
         QtTest.QTest.mouseRelease(
             tab.get_mode().server_status.server_button, QtCore.Qt.LeftButton
         )
+        QtTest.QTest.qWait(500)
         self.assertEqual(
             tab.get_mode().server_status.status,
             tab.get_mode().server_status.STATUS_STOPPED,

--- a/tests/test_gui_share.py
+++ b/tests/test_gui_share.py
@@ -135,11 +135,13 @@ class TestShare(GuiBaseTest):
                     ),
                 )
 
-            tmp_file = tempfile.NamedTemporaryFile("wb")
+            tmp_file = tempfile.NamedTemporaryFile("wb", delete=False)
             tmp_file.write(r.content)
+            tmp_file.close()
 
             with open(tmp_file.name, "r") as f:
                 self.assertEqual("onionshare", f.read())
+            os.remove(tmp_file.name)
 
         QtTest.QTest.qWait(500)
 

--- a/tests/test_gui_tabs.py
+++ b/tests/test_gui_tabs.py
@@ -20,7 +20,7 @@ class TestTabs(GuiBaseTest):
             tab.get_mode().server_status.status,
             tab.get_mode().server_status.STATUS_WORKING,
         )
-        QtTest.QTest.qWait(500)
+        QtTest.QTest.qWait(1000)
         self.assertEqual(
             tab.get_mode().server_status.status,
             tab.get_mode().server_status.STATUS_STARTED,
@@ -138,21 +138,27 @@ class TestTabs(GuiBaseTest):
         self.gui.tabs.widget(1).share_button.click()
         self.assertFalse(self.gui.tabs.widget(1).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(1).share_mode.isVisible())
-        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to share')
+        self.assertEqual(
+            self.gui.status_bar.server_status_label.text(), "Ready to share"
+        )
 
         # New tab, receive files
         self.gui.tabs.new_tab_button.click()
         self.gui.tabs.widget(2).receive_button.click()
         self.assertFalse(self.gui.tabs.widget(2).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(2).receive_mode.isVisible())
-        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to receive')
+        self.assertEqual(
+            self.gui.status_bar.server_status_label.text(), "Ready to receive"
+        )
 
         # New tab, publish website
         self.gui.tabs.new_tab_button.click()
         self.gui.tabs.widget(3).website_button.click()
         self.assertFalse(self.gui.tabs.widget(3).new_tab.isVisible())
         self.assertTrue(self.gui.tabs.widget(3).website_mode.isVisible())
-        self.assertEqual(self.gui.status_bar.server_status_label.text(), 'Ready to share')
+        self.assertEqual(
+            self.gui.status_bar.server_status_label.text(), "Ready to share"
+        )
 
         # Close tabs
         self.gui.tabs.tabBar().tabButton(0, QtWidgets.QTabBar.RightSide).click()


### PR DESCRIPTION
Resolves #1076 

You can now run the tests in Linux, macOS, and Windows, and they all run and pass.

For windows, you can run `poetry run tests\run.bat`.