### PR TITLE
Explicitly try to start a v2 onion in order to evaluate the ability to support (legacy) stealth mode

### DIFF
--- a/onionshare/onion.py
+++ b/onionshare/onion.py
@@ -181,6 +181,9 @@ class Onion(object):
         # Start out not connected to Tor
         self.connected_to_tor = False
 
+        # Assigned later if we are using stealth mode
+        self.auth_string = None
+
     def connect(
         self,
         custom_settings=None,
@@ -549,7 +552,8 @@ class Onion(object):
         # Do the versions of stem and tor that I'm using support stealth onion services?
         try:
             res = self.c.create_ephemeral_hidden_service(
-                {1: 1}, basic_auth={"onionshare": None}, await_publication=False
+                {1: 1}, basic_auth={"onionshare": None}, await_publication=False,
+                key_type="NEW",key_content="RSA1024"
             )
             tmp_service_id = res.service_id
             self.c.remove_ephemeral_hidden_service(tmp_service_id)
@@ -655,8 +659,8 @@ class Onion(object):
             "onion", "hidservauth_string"
         ):
             auth_cookie = list(res.client_auth.values())[0]
-            auth_string = f"HidServAuth {onion_host} {auth_cookie}"
-            mode_settings.set("onion", "hidservauth_string", auth_string)
+            self.auth_string = f"HidServAuth {onion_host} {auth_cookie}"
+            mode_settings.set("onion", "hidservauth_string", self.auth_string)
 
         return onion_host
 


### PR DESCRIPTION
 Fixes #1169 . What was happening was the `supports_stealth` test was, since newer Tor, starting a v3 onion by default, so it was indeed honestly saying that it could not support stealth mode (since Client Auth doesn't work via Stem for v3 onions yet).

While I was there, I encountered a separate crash: the app tries to pass the `auth_string` attribute of the `Onion` object back up to the GUI for the clipboard, but we no longer had that attribute defined in a fetchable way.

```
[Aug 27 2020 02:54:25 PM] ModeSettings.set: updating snowbound-preorder-unraveled: onion.hidservauth_string = HidServAuth rh2vqhsw4zrfd6b4.onion UsVNXJI74hjNIS8K9ieZPA
Traceback (most recent call last):
  File "/home/user/git/onionshare/onionshare_gui/threads.py", line 84, in run
    self.mode.settings, await_publication=True
  File "/home/user/git/onionshare/onionshare/onionshare.py", line 87, in start_onion_service
    self.auth_string = self.onion.auth_string
AttributeError: 'Onion' object has no attribute 'auth_string'
Aborted
``` 