### PR TITLE
Fix Debian and Fedora packaging

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -80,13 +80,13 @@ Install the needed dependencies:
 **For Debian-like distros:**
 
 ```
-apt install -y python3-flask python3-stem python3-pyqt5 python3-crypto python3-socks  python-nautilus tor obfs4proxy python3-pytest python3-pytestqt build-essential fakeroot python3-all python3-stdeb dh-python python3-flask-httpauth python3-distutils python3-psutil python3-watchdog
+apt install -y python3-flask python3-stem python3-pyqt5 python3-crypto python3-socks python3-nautilus tor obfs4proxy python3-pytest python3-pytestqt build-essential fakeroot python3-all python3-stdeb dh-python python3-flask-httpauth python3-distutils python3-psutil python3-socketio python3-flask-socketio python3-qrcode
 ```
 
 **For Fedora-like distros:**
 
 ```
-dnf install -y python3-flask python3-flask-httpauth python3-stem python3-qt5 python3-crypto python3-pysocks nautilus-python tor obfs4 python3-pytest rpm-build python3-psutil python3-watchdog
+dnf install -y python3-flask python3-flask-httpauth python3-stem python3-qt5 python3-crypto python3-pysocks nautilus-python tor obfs4 python3-pytest rpm-build python3-psutil python3-socketio python3-flask-socketio python3-qrcode
 ```
 
 After that you can try both the CLI and the GUI version of OnionShare:

--- a/install/build_rpm.sh
+++ b/install/build_rpm.sh
@@ -9,7 +9,7 @@ VERSION=`cat share/version.txt`
 rm -r build dist >/dev/null 2>&1
 
 # build binary package
-python3 setup.py bdist_rpm --requires="python3-flask, python3-flask-httpauth, python3-stem, python3-qt5, python3-crypto, python3-pysocks, nautilus-python, tor, obfs4"
+python3 setup.py bdist_rpm --requires="python3-flask, python3-flask-httpauth, python3-stem, python3-qt5, python3-crypto, python3-pysocks, nautilus-python, tor, obfs4, python3-psutil, python3-socketio, python3-flask-socketio, python3-qrcode"
 
 # install it
 echo ""

--- a/onionshare_gui/tab/tab.py
+++ b/onionshare_gui/tab/tab.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import queue
-from PyQt5 import QtCore, QtWidgets, QtGui, QtSvg
+from PyQt5 import QtCore, QtWidgets, QtGui
 
 from onionshare import strings
 from onionshare.onionshare import OnionShare

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package3: onionshare
-Depends3: python3, python3-flask, python3-flask-httpauth, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python-nautilus, tor, obfs4proxy, python3-psutil
-Build-Depends: python3, python3-all, python3-pytest, python3-requests, python3-flask, python3-flask-httpauth, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python3-psutil
+Depends3: python3, python3-flask, python3-flask-httpauth, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python3-nautilus, tor, obfs4proxy, python3-psutil, python3-socketio, python3-flask-socketio, python3-qrcode
+Build-Depends: python3, python3-all, python3-pytest, python3-requests, python3-flask, python3-flask-httpauth, python3-stem, python3-pyqt5, python3-crypto, python3-socks, python3-distutils, python3-psutil, python3-socketio, python3-flask-socketio, python3-qrcode
 Suite: disco
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
This fixes the `build_deb.sh` and `build_rpm.sh` scripts, and the build instructions for building Debian and Fedora packages.