### PR TITLE
Make CLI arg --autostop-sharing false by default

### DIFF
--- a/onionshare/__init__.py
+++ b/onionshare/__init__.py
@@ -183,7 +183,7 @@ def main(cwd=None):
         "--autostop-sharing",
         action="store_true",
         dest="autostop_sharing",
-        default=True,
+        default=False,
         help="Share files: Stop sharing after files have been sent",
     )
     # Receive args


### PR DESCRIPTION
`args.autostop_sharing` defaults to `True` and the argument parser's action is `store_true` which means the argument will always be `True`.
This PR sets the default to `False` which is probably what was intended.