### PR TITLE
Fix username updation to both the sessions

### DIFF
--- a/cli/onionshare_cli/resources/static/js/chat.js
+++ b/cli/onionshare_cli/resources/static/js/chat.js
@@ -1,7 +1,12 @@
 $(function () {
   $(document).ready(function () {
     $('.chat-container').removeClass('no-js');
-    var socket = io.connect('http://' + document.domain + ':' + location.port + '/chat');
+    var socket = io.connect(
+      'http://' + document.domain + ':' + location.port + '/chat',
+      {
+        transports: ['websocket']
+      }
+    );
 
     // Store current username received from app context
     var current_username = $('#username').val();

--- a/cli/onionshare_cli/resources/static/js/chat.js
+++ b/cli/onionshare_cli/resources/static/js/chat.js
@@ -88,7 +88,6 @@ var emitMessage = function (socket) {
 var updateUsername = function (socket) {
   var username = $('#username').val();
   if (!checkUsernameExists(username)) {
-    socket.emit('update_username', { username: username });
     $.ajax({
       method: 'POST',
       url: `http://${document.domain}:${location.port}/update-session-username`,
@@ -97,6 +96,9 @@ var updateUsername = function (socket) {
       data: JSON.stringify({ 'username': username })
     }).done(function (response) {
       console.log(response);
+      if (response.success && response.username == username) {
+        socket.emit('update_username', { username: username });
+      }
     });
     return username;
   }

--- a/cli/onionshare_cli/resources/static/js/chat.js
+++ b/cli/onionshare_cli/resources/static/js/chat.js
@@ -50,7 +50,8 @@ $(function () {
     // Keep buttons disabled unless changed or not empty
     $('#username').on('keyup', function (event) {
       if ($('#username').val() !== '' && $('#username').val() !== current_username) {
-        if (event.keyCode == 13) {
+        if (event.keyCode == 13 || event.which == 13) {
+          this.blur();
           current_username = updateUsername(socket) || current_username;
         }
       }

--- a/cli/onionshare_cli/web/chat_mode.py
+++ b/cli/onionshare_cli/web/chat_mode.py
@@ -66,7 +66,8 @@ class ChatModeWeb:
             )
             session["room"] = self.web.settings.default_settings["chat"]["room"]
             self.web.add_request(
-                request.path, {"id": history_id, "status_code": 200},
+                request.path,
+                {"id": history_id, "status_code": 200},
             )
 
             self.web.add_request(self.web.REQUEST_LOAD, request.path)
@@ -83,14 +84,23 @@ class ChatModeWeb:
         def update_session_username():
             history_id = self.cur_history_id
             data = request.get_json()
-            if data.get("username", "") not in self.connected_users:
+            if (
+                data.get("username", "")
+                and data.get("username", "") not in self.connected_users
+            ):
                 session["name"] = data.get("username", session.get("name"))
             self.web.add_request(
-                request.path, {"id": history_id, "status_code": 200},
+                request.path,
+                {"id": history_id, "status_code": 200},
             )
 
             self.web.add_request(self.web.REQUEST_LOAD, request.path)
-            r = make_response(jsonify(username=session.get("name"), success=True,))
+            r = make_response(
+                jsonify(
+                    username=session.get("name"),
+                    success=True,
+                )
+            )
             return self.web.add_security_headers(r)
 
         @self.web.socketio.on("joined", namespace="/chat")
@@ -125,7 +135,7 @@ class ChatModeWeb:
             """Sent by a client when the user updates their username.
             The message is sent to all people in the room."""
             current_name = session.get("name")
-            if message["username"] not in self.connected_users:
+            if message.get("username", ""):
                 session["name"] = message["username"]
                 self.connected_users[
                     self.connected_users.index(current_name)


### PR DESCRIPTION
Fixes #1210 

Updating the socket session only after a success response is received from the POST request to update the flask session. That way, the conflicting race condition in connected_users is avoided.