### PR TITLE
Adjusts height of title based on length of text

### DIFF
--- a/desktop/src/onionshare/gui_common.py
+++ b/desktop/src/onionshare/gui_common.py
@@ -260,7 +260,7 @@ class GuiCommon:
                 QLabel {
                     text-align: center;
                     color: #333333;
-                    font-size: 28px;
+                    font-size: 25px;
                 }
                 """,
             # Share mode and child widget styles

--- a/desktop/src/onionshare/tab/tab.py
+++ b/desktop/src/onionshare/tab/tab.py
@@ -53,16 +53,22 @@ class NewTabButton(QtWidgets.QPushButton):
         )
         self.image_label.setAlignment(QtCore.Qt.AlignCenter)
         self.image_label.setStyleSheet(self.common.gui.css["new_tab_button_image"])
-        self.image_label.setGeometry(0, 0, self.width(), 200)
+        self.image_label.setGeometry(0, 0, self.width(), 190)
         self.image_label.show()
 
         # Title
         self.title_label = QtWidgets.QLabel(title, parent=self)
+        self.title_label.setWordWrap(True)
         self.title_label.setAlignment(QtCore.Qt.AlignCenter)
         self.title_label.setStyleSheet(self.common.gui.css["new_tab_title_text"])
-        self.title_label.setGeometry(
-            (self.width() - 250) / 2, self.height() - 100, 250, 30
-        )
+        if self.title_label.sizeHint().width() >= 250:
+            self.title_label.setGeometry(
+                (self.width() - 250) / 2, self.height() - 120, 250, 60
+            )
+        else:
+            self.title_label.setGeometry(
+                (self.width() - 250) / 2, self.height() - 100, 250, 30
+            )
         self.title_label.show()
 
         # Text


### PR DESCRIPTION
Fixes #1240 

I have reduced the font size from 28px to 25px. Also adjusted the height of image a little. And added a logic to check if sizeHint width of the text is greated the geometry width, then adjust the height and starting y.

This is how it looks.
![Screenshot from 2020-12-13 20-59-41](https://user-images.githubusercontent.com/9530293/102017151-22e34400-3d8b-11eb-8f1b-a91dcd6f1957.png)

If it goes more than 2 lines in wordwrap, then it will again be an issue, but I checked in few different languages and looked okay.
