### PR TITLE
"Stopped because auto-stop timer ran out" string should get displayed

### DIFF
--- a/desktop/src/onionshare/tab/mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/__init__.py
@@ -177,8 +177,7 @@ class Mode(QtWidgets.QWidget):
 
                     self.status_bar.clearMessage()
                     if not self.app.autostop_timer_thread.is_alive():
-                        if self.autostop_timer_finished_should_stop_server():
-                            self.server_status.stop_server()
+                        self.autostop_timer_finished_should_stop_server()
 
     def timer_callback_custom(self):
         """


### PR DESCRIPTION
Fixes #1183 