### PR TITLE
Fixes macOS layout while maintaining similar layout in linux

### DIFF
--- a/desktop/src/onionshare/gui_common.py
+++ b/desktop/src/onionshare/gui_common.py
@@ -292,12 +292,10 @@ class GuiCommon:
                 QLabel {
                     color: #4E064F;
                     font-size: 48px;
-                    margin-bottom: 72px;
                 }""",
             "share_file_selection_drop_here_label": """
                 QLabel {
                     color: #666666;
-                    margin-bottom: 48px;
                 }""",
             "share_file_selection_drop_count_label": """
                 QLabel {

--- a/desktop/src/onionshare/tab/mode/file_selection.py
+++ b/desktop/src/onionshare/tab/mode/file_selection.py
@@ -72,8 +72,8 @@ class DropHereWidget(QtWidgets.QWidget):
     def resize(self, w, h):
         self.setGeometry(0, 0, w, h)
         self.image_label.setGeometry(0, 0, w, h - 100)
-        self.header_label.setGeometry(0, 340, w, h - 340)
-        self.text_label.setGeometry(0, 410, w, h - 410)
+        self.header_label.setGeometry(0, 310, w, h - 380)
+        self.text_label.setGeometry(0, 360, w, h - 400)
 
 
 class DropCountLabel(QtWidgets.QLabel):


### PR DESCRIPTION
In macOS, in share and website mode, the text gets cut off unless
it is full screen. This is mostly because of margin being applied
by css. Here I have tried to implement a similar layout using qt
instead of CSS so it behaves reasonably everywhere.

I was able to reproduce https://github.com/micahflee/onionshare/issues/1186. This
fix doesn't change the current layout much while fixing it in my mac as well.

Before (in debian):
![Screenshot from 2021-01-09 02-09-34](https://user-images.githubusercontent.com/9530293/104853658-453b2500-5928-11eb-8d09-35e4eb0cbfb9.png)

After (in debian):
![Screenshot from 2021-01-09 02-10-07](https://user-images.githubusercontent.com/9530293/104853663-4d936000-5928-11eb-978b-4849d1574a5d.png)


Before(in mac):
<img width="1037" alt="signal-2021-01-18-010320" src="https://user-images.githubusercontent.com/9530293/104853851-86800480-5929-11eb-9be1-7d44f133c5de.png">


After (in mac):
<img width="1036" alt="signal-2021-01-18-010604" src="https://user-images.githubusercontent.com/9530293/104853857-913a9980-5929-11eb-9ad6-a6c1937be4b2.png">

