### PR TITLE
Fix the filename of the obfs4proxy binary on macOS

### DIFF
--- a/desktop/src/onionshare/gui_common.py
+++ b/desktop/src/onionshare/gui_common.py
@@ -391,7 +391,7 @@ class GuiCommon:
         elif self.common.platform == "Darwin":
             base_path = self.get_resource_path("tor")
             tor_path = os.path.join(base_path, "tor")
-            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy.exe")
+            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy")
             tor_geo_ip_file_path = os.path.join(base_path, "geoip")
             tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
         elif self.common.platform == "BSD":


### PR DESCRIPTION
Fixes #1311