### PR TITLE
Fix the call to start_onion_service in CLI mode when using autostart timer

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -370,7 +370,7 @@ def main(cwd=None):
                 )
                 sys.exit()
 
-            app.start_onion_service(mode, mode_settings, False, True)
+            app.start_onion_service(mode, mode_settings, False)
             url = build_url(mode_settings, app, web)
             schedule = datetime.now() + timedelta(seconds=autostart_timer)
             if mode == "receive":
@@ -412,7 +412,7 @@ def main(cwd=None):
     except KeyboardInterrupt:
         print("")
         sys.exit()
-    except (TorTooOld, TorErrorProtocolError) as e:
+    except (TorTooOldEphemeral, TorTooOldStealth, TorErrorProtocolError) as e:
         print("")
         print(e.args[0])
         sys.exit()


### PR DESCRIPTION
The call to `start_onion_service` in the CLI needs to pass `await_publication=False` when in autostart mode, but it had one extra positional arg which dated from an older version of the function, to do with 'save private key', which is no longer there.

There was also an issue with the TorTooOld exception handlers, as we have two separate exception types now that can be raised in `start_onion_service()`.

Fixes #1315 