### PR TITLE
Make verbose output prettier with terminal colors

### DIFF
--- a/cli/onionshare_cli/common.py
+++ b/cli/onionshare_cli/common.py
@@ -43,6 +43,10 @@ class Common:
     The Common object is shared amongst all parts of OnionShare.
     """
 
+    C_RESET = "\033[0m"
+    C_LIGHTGRAY = "\033[37m"
+    C_DARKGRAY = "\033[90m"
+
     def __init__(self, verbose=False):
         self.verbose = verbose
 
@@ -68,10 +72,9 @@ class Common:
         """
         if self.verbose:
             timestamp = time.strftime("%b %d %Y %X")
-
-            final_msg = f"[{timestamp}] {module}.{func}"
+            final_msg = f"{self.C_DARKGRAY}[{timestamp}]{self.C_RESET} {self.C_LIGHTGRAY}{module}.{func}{self.C_RESET}"
             if msg:
-                final_msg = f"{final_msg}: {msg}"
+                final_msg = f"{final_msg}{self.C_LIGHTGRAY}: {msg}{self.C_RESET}"
             print(final_msg)
 
     def get_resource_path(self, filename):

--- a/cli/tests/test_cli_common.py
+++ b/cli/tests/test_cli_common.py
@@ -241,5 +241,11 @@ class TestLog:
             output = buf.getvalue()
 
         line_one, line_two, _ = output.split("\n")
-        assert line_one == "[Jun 06 2013 11:05:00] TestModule.dummy_func"
-        assert line_two == "[Jun 06 2013 11:05:00] TestModule.dummy_func: TEST_MSG"
+        assert (
+            "[Jun 06 2013 11:05:00]" in line_one and "TestModule.dummy_func" in line_one
+        )
+        assert (
+            "[Jun 06 2013 11:05:00]" in line_two
+            and "TestModule.dummy_func" in line_two
+            and "TEST_MSG" in line_two
+        )


### PR DESCRIPTION
When you run OnionShare with `-v` for verbose output, this makes the timestamps dark gray and the messages light gray, to more easily differentiate from the regular output which is white.

![Screenshot_2021-04-12_15-42-59](https://user-images.githubusercontent.com/156128/114451923-d297b980-9ba5-11eb-950d-ca545d098949.png)
