### PR TITLE
Allow custom title for each onion service

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -144,6 +144,12 @@ def main(cwd=None):
     )
     # General args
     parser.add_argument(
+        "--title",
+        metavar="TITLE",
+        default=None,
+        help="Set a title",
+    )
+    parser.add_argument(
         "--public",
         action="store_true",
         dest="public",
@@ -234,6 +240,7 @@ def main(cwd=None):
     connect_timeout = int(args.connect_timeout)
     config_filename = args.config
     persistent_filename = args.persistent
+    title = args.title
     public = bool(args.public)
     autostart_timer = int(args.autostart_timer)
     autostop_timer = int(args.autostop_timer)
@@ -280,6 +287,7 @@ def main(cwd=None):
 
     if mode_settings.just_created:
         # This means the mode settings were just created, not loaded from disk
+        mode_settings.set("general", "title", title)
         mode_settings.set("general", "public", public)
         mode_settings.set("general", "autostart_timer", autostart_timer)
         mode_settings.set("general", "autostop_timer", autostop_timer)

--- a/cli/onionshare_cli/mode_settings.py
+++ b/cli/onionshare_cli/mode_settings.py
@@ -42,6 +42,7 @@ class ModeSettings:
             },
             "persistent": {"mode": None, "enabled": False},
             "general": {
+                "title": None,
                 "public": False,
                 "autostart_timer": False,
                 "autostop_timer": False,

--- a/cli/onionshare_cli/resources/templates/chat.html
+++ b/cli/onionshare_cli/resources/templates/chat.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>OnionShare</title>
+  <title>{% if title %}{{ title }}{% else %}OnionShare Chat{% endif %}</title>
   <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon">
   <link rel="stylesheet" rel="subresource" type="text/css" href="{{ static_url_path }}/css/style.css" media="all">
 </head>
@@ -11,7 +11,7 @@
 
   <header class="clearfix">
     <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
-    <h1>OnionShare</h1>
+    <h1>{% if title %}{{ title }}{% else %}OnionShare Chat{% endif %}</h1>
   </header>
   <noscript>
     <p>

--- a/cli/onionshare_cli/resources/templates/listing.html
+++ b/cli/onionshare_cli/resources/templates/listing.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>OnionShare</title>
+  <title>{% if title %}{{ title }}{% else %}OnionShare{% endif %}</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon" />
@@ -14,7 +14,7 @@
   <header class="d-flex">
     <div class="logo-container">
       <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
-      <h1>OnionShare</h1>
+      <h1>{% if title %}{{ title }}{% else %}OnionShare{% endif %}</h1>
     </div>
   </header>
 

--- a/cli/onionshare_cli/resources/templates/receive.html
+++ b/cli/onionshare_cli/resources/templates/receive.html
@@ -1,46 +1,49 @@
 <!DOCTYPE html>
 <html>
- <head>
-    <title>OnionShare</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1"> 
-    <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="stylesheet" rel="subresource" type="text/css" href="{{ static_url_path }}/css/style.css" media="all">
-  </head>
-  <body>
 
-    <header class="clearfix">
-        <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
-        <h1>OnionShare</h1>
-    </header>
+<head>
+  <title>{% if title %}{{ title }}{% else %}OnionShare Dropbox{% endif %}</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="stylesheet" rel="subresource" type="text/css" href="{{ static_url_path }}/css/style.css" media="all">
+</head>
 
-    <div class="upload-wrapper">
-      <p><img class="logo" src="{{ static_url_path }}/img/logo_large.png" title="OnionShare"></p>
+<body>
 
-      <p class="upload-header">Send Files</p>
-      <p class="upload-description">Select the files you want to send, then click "Send Files"...</p>
+  <header class="clearfix">
+    <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
+    <h1>{% if title %}{{ title }}{% else %}OnionShare Dropbox{% endif %}</h1>
+  </header>
 
-      <div id="uploads"></div>
+  <div class="upload-wrapper">
+    <p><img class="logo" src="{{ static_url_path }}/img/logo_large.png" title="OnionShare"></p>
 
-      <div>
-        <ul id="flashes" class="flashes">
-          {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-              {% for category, message in messages %}
-                <li class="{{ category }}">{{ message }}</li>
-              {% endfor %}
-            {% endif %}
-          {% endwith %}
-        </ul>
-      </div>
+    <p class="upload-header">Send Files</p>
+    <p class="upload-description">Select the files you want to send, then click "Send Files"...</p>
 
-      <form id="send" method="post" enctype="multipart/form-data" action="/upload">
-         <p><input type="file" id="file-select" name="file[]" multiple /></p>
-         <p><button type="submit" id="send-button" class="button">Send Files</button></p>
-      </form>
+    <div id="uploads"></div>
 
+    <div>
+      <ul id="flashes" class="flashes">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        {% for category, message in messages %}
+        <li class="{{ category }}">{{ message }}</li>
+        {% endfor %}
+        {% endif %}
+        {% endwith %}
+      </ul>
     </div>
-    <script src="{{ static_url_path }}/js/jquery-3.5.1.min.js"></script>
-    <script async src="{{ static_url_path }}/js/receive.js" id="receive-script"></script>
-  </body>
+
+    <form id="send" method="post" enctype="multipart/form-data" action="/upload">
+      <p><input type="file" id="file-select" name="file[]" multiple /></p>
+      <p><button type="submit" id="send-button" class="button">Send Files</button></p>
+    </form>
+
+  </div>
+  <script src="{{ static_url_path }}/js/jquery-3.5.1.min.js"></script>
+  <script async src="{{ static_url_path }}/js/receive.js" id="receive-script"></script>
+</body>
+
 </html>

--- a/cli/onionshare_cli/resources/templates/send.html
+++ b/cli/onionshare_cli/resources/templates/send.html
@@ -2,9 +2,9 @@
 <html>
 
 <head>
-  <title>OnionShare</title>
+  <title>{% if title %}{{ title }}{% else %}OnionShare{% endif %}</title>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1"> 
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon">
   <link rel="stylesheet" rel="subresource" type="text/css" href="{{ static_url_path }}/css/style.css" media="all">
   <meta name="onionshare-filename" content="{{ filename }}">
@@ -16,7 +16,7 @@
   <header class="d-flex">
     <div class="logo-container">
       <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
-      <h1>OnionShare</h1>
+      <h1>{% if title %}{{ title }}{% else %}OnionShare{% endif %}</h1>
     </div>
     <div class="information d-flex">
       <div>Total size: <strong>{{ filesize_human }}</strong> {% if is_zipped %} (compressed){% endif %}</div>
@@ -25,10 +25,11 @@
   </header>
 
   {% if breadcrumbs %}
-      <ul class="breadcrumbs">
-        {% for breadcrumb in breadcrumbs %}<li><a href="{{ breadcrumb[1] }}">{{ breadcrumb[0] }}</a> <span class="sep">&#8227;</span></li>{% endfor %}<li>{{ breadcrumbs_leaf }}</li>
-      </ul>
-    {% endif %}
+  <ul class="breadcrumbs">
+    {% for breadcrumb in breadcrumbs %}<li><a href="{{ breadcrumb[1] }}">{{ breadcrumb[0] }}</a> <span
+        class="sep">&#8227;</span></li>{% endfor %}<li>{{ breadcrumbs_leaf }}</li>
+  </ul>
+  {% endif %}
 
   <div class="file-list" id="file-list">
     <div class="d-flex">

--- a/cli/onionshare_cli/resources/templates/thankyou.html
+++ b/cli/onionshare_cli/resources/templates/thankyou.html
@@ -4,7 +4,7 @@
 <head>
   <title>OnionShare is closed</title>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1"> 
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="{{ static_url_path }}/img/favicon.ico" rel="icon" type="image/x-icon">
   <link rel="stylesheet" rel="subresource" type="text/css" href="{{ static_url_path }}/css/style.css" media="all">
 </head>
@@ -12,7 +12,7 @@
 <body>
   <header class="clearfix">
     <img class="logo" src="{{ static_url_path }}/img/logo.png" title="OnionShare">
-    <h1>OnionShare</h1>
+    <h1>{% if title %}{{ title }}{% else %}OnionShare{% endif %}</h1>
   </header>
 
   <div class="info-wrapper">

--- a/cli/onionshare_cli/web/chat_mode.py
+++ b/cli/onionshare_cli/web/chat_mode.py
@@ -18,12 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from flask import (
-    request,
-    render_template,
-    make_response,
-    jsonify,
-    session)
+from flask import request, render_template, make_response, jsonify, session
 from flask_socketio import emit, join_room, leave_room
 
 
@@ -72,6 +67,7 @@ class ChatModeWeb:
                     "chat.html",
                     static_url_path=self.web.static_url_path,
                     username=session.get("name"),
+                    title=self.web.settings.get("general", "title"),
                 )
             )
             return self.web.add_security_headers(r)

--- a/cli/onionshare_cli/web/receive_mode.py
+++ b/cli/onionshare_cli/web/receive_mode.py
@@ -64,7 +64,9 @@ class ReceiveModeWeb:
             self.web.add_request(self.web.REQUEST_LOAD, request.path)
             r = make_response(
                 render_template(
-                    "receive.html", static_url_path=self.web.static_url_path
+                    "receive.html",
+                    static_url_path=self.web.static_url_path,
+                    title=self.web.settings.get("general", "title"),
                 )
             )
             return self.web.add_security_headers(r)
@@ -168,6 +170,7 @@ class ReceiveModeWeb:
                             "new_body": render_template(
                                 "thankyou.html",
                                 static_url_path=self.web.static_url_path,
+                                title=self.web.settings.get("general", "title"),
                             )
                         }
                     )
@@ -176,6 +179,7 @@ class ReceiveModeWeb:
                     r = make_response(
                         render_template("thankyou.html"),
                         static_url_path=self.web.static_url_path,
+                        title=self.web.settings.get("general", "title"),
                     )
                     return self.web.add_security_headers(r)
 

--- a/cli/onionshare_cli/web/share_mode.py
+++ b/cli/onionshare_cli/web/share_mode.py
@@ -230,6 +230,7 @@ class ShareModeWeb(SendBaseModeWeb):
                 is_zipped=self.is_zipped,
                 static_url_path=self.web.static_url_path,
                 download_individual_files=self.download_individual_files,
+                title=self.web.settings.get("general", "title"),
             )
         )
 

--- a/cli/onionshare_cli/web/website_mode.py
+++ b/cli/onionshare_cli/web/website_mode.py
@@ -60,6 +60,7 @@ class WebsiteModeWeb(SendBaseModeWeb):
                 breadcrumbs=breadcrumbs,
                 breadcrumbs_leaf=breadcrumbs_leaf,
                 static_url_path=self.web.static_url_path,
+                title=self.web.settings.get("general", "title"),
             )
         )
 

--- a/desktop/src/onionshare/resources/locale/en.json
+++ b/desktop/src/onionshare/resources/locale/en.json
@@ -165,7 +165,7 @@
     "gui_quit_warning_cancel": "Cancel",
     "mode_settings_advanced_toggle_show": "Show advanced settings",
     "mode_settings_advanced_toggle_hide": "Hide advanced settings",
-    "mode_settings_title_label": "Title",
+    "mode_settings_title_label": "Custom title",
     "mode_settings_persistent_checkbox": "Save this tab, and automatically open it when I open OnionShare",
     "mode_settings_public_checkbox": "Don't use a password",
     "mode_settings_autostart_timer_checkbox": "Start onion service at scheduled time",

--- a/desktop/src/onionshare/resources/locale/en.json
+++ b/desktop/src/onionshare/resources/locale/en.json
@@ -165,6 +165,7 @@
     "gui_quit_warning_cancel": "Cancel",
     "mode_settings_advanced_toggle_show": "Show advanced settings",
     "mode_settings_advanced_toggle_hide": "Hide advanced settings",
+    "mode_settings_title_label": "Title",
     "mode_settings_persistent_checkbox": "Save this tab, and automatically open it when I open OnionShare",
     "mode_settings_public_checkbox": "Don't use a password",
     "mode_settings_autostart_timer_checkbox": "Start onion service at scheduled time",

--- a/desktop/src/onionshare/tab/mode/chat_mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/chat_mode/__init__.py
@@ -68,6 +68,11 @@ class ChatMode(Mode):
         self.image = QtWidgets.QWidget()
         self.image.setLayout(image_layout)
 
+        # Set title placeholder
+        self.mode_settings_widget.title_lineedit.setPlaceholderText(
+            strings._("gui_tab_name_chat")
+        )
+
         # Server status
         self.server_status.set_mode("chat")
         self.server_status.server_started_finished.connect(self.update_primary_action)

--- a/desktop/src/onionshare/tab/mode/mode_settings_widget.py
+++ b/desktop/src/onionshare/tab/mode/mode_settings_widget.py
@@ -236,11 +236,9 @@ class ModeSettingsWidget(QtWidgets.QWidget):
             elif self.tab_mode == None:
                 pass
         else:
-            self.settings.set("general", "title", self.title_lineedit.text())
-            shortened_title = self.title_lineedit.text()
-            if len(shortened_title) > 11:
-                shortened_title = shortened_title[:10] + "..."
-            self.tab.change_title.emit(self.tab.tab_id, shortened_title)
+            title = self.title_lineedit.text()
+            self.settings.set("general", "title", title)
+            self.tab.change_title.emit(self.tab.tab_id, title)
 
     def persistent_checkbox_clicked(self):
         self.settings.set("persistent", "enabled", self.persistent_checkbox.isChecked())

--- a/desktop/src/onionshare/tab/mode/mode_settings_widget.py
+++ b/desktop/src/onionshare/tab/mode/mode_settings_widget.py
@@ -39,6 +39,16 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         # Downstream Mode need to fill in this layout with its settings
         self.mode_specific_layout = QtWidgets.QVBoxLayout()
 
+        # Title
+        title_label = QtWidgets.QLabel(strings._("mode_settings_title_label"))
+        self.title_lineedit = QtWidgets.QLineEdit()
+        self.title_lineedit.editingFinished.connect(self.title_editing_finished)
+        if self.settings.get("general", "title"):
+            self.title_lineedit.setText(self.settings.get("general", "title"))
+        title_layout = QtWidgets.QHBoxLayout()
+        title_layout.addWidget(title_label)
+        title_layout.addWidget(self.title_lineedit)
+
         # Persistent
         self.persistent_checkbox = QtWidgets.QCheckBox()
         self.persistent_checkbox.clicked.connect(self.persistent_checkbox_clicked)
@@ -162,6 +172,7 @@ class ModeSettingsWidget(QtWidgets.QWidget):
 
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(self.mode_specific_layout)
+        layout.addLayout(title_layout)
         layout.addWidget(self.persistent_checkbox)
         layout.addWidget(self.public_checkbox)
         layout.addWidget(self.advanced_widget)
@@ -202,6 +213,34 @@ class ModeSettingsWidget(QtWidgets.QWidget):
                 # If using v3, hide legacy and client auth options
                 self.legacy_checkbox.hide()
                 self.client_auth_checkbox.hide()
+
+    def title_editing_finished(self):
+        if self.title_lineedit.text() == "":
+            self.settings.set("general", "title", None)
+            if self.tab.mode == self.common.gui.MODE_SHARE:
+                self.tab.change_title.emit(
+                    self.tab.tab_id, strings._("gui_tab_name_share")
+                )
+            elif self.tab.mode == self.common.gui.MODE_RECEIVE:
+                self.tab.change_title.emit(
+                    self.tab.tab_id, strings._("gui_tab_name_receive")
+                )
+            elif self.tab.mode == self.common.gui.MODE_WEBSITE:
+                self.tab.change_title.emit(
+                    self.tab.tab_id, strings._("gui_tab_name_website")
+                )
+            elif self.tab.mode == self.common.gui.MODE_CHAT:
+                self.tab.change_title.emit(
+                    self.tab.tab_id, strings._("gui_tab_name_chat")
+                )
+            elif self.tab_mode == None:
+                pass
+        else:
+            self.settings.set("general", "title", self.title_lineedit.text())
+            shortened_title = self.title_lineedit.text()
+            if len(shortened_title) > 11:
+                shortened_title = shortened_title[:10] + "..."
+            self.tab.change_title.emit(self.tab.tab_id, shortened_title)
 
     def persistent_checkbox_clicked(self):
         self.settings.set("persistent", "enabled", self.persistent_checkbox.isChecked())

--- a/desktop/src/onionshare/tab/mode/mode_settings_widget.py
+++ b/desktop/src/onionshare/tab/mode/mode_settings_widget.py
@@ -39,16 +39,6 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         # Downstream Mode need to fill in this layout with its settings
         self.mode_specific_layout = QtWidgets.QVBoxLayout()
 
-        # Title
-        title_label = QtWidgets.QLabel(strings._("mode_settings_title_label"))
-        self.title_lineedit = QtWidgets.QLineEdit()
-        self.title_lineedit.editingFinished.connect(self.title_editing_finished)
-        if self.settings.get("general", "title"):
-            self.title_lineedit.setText(self.settings.get("general", "title"))
-        title_layout = QtWidgets.QHBoxLayout()
-        title_layout.addWidget(title_label)
-        title_layout.addWidget(self.title_lineedit)
-
         # Persistent
         self.persistent_checkbox = QtWidgets.QCheckBox()
         self.persistent_checkbox.clicked.connect(self.persistent_checkbox_clicked)
@@ -66,6 +56,16 @@ class ModeSettingsWidget(QtWidgets.QWidget):
             self.public_checkbox.setCheckState(QtCore.Qt.Checked)
         else:
             self.public_checkbox.setCheckState(QtCore.Qt.Unchecked)
+
+        # Title
+        title_label = QtWidgets.QLabel(strings._("mode_settings_title_label"))
+        self.title_lineedit = QtWidgets.QLineEdit()
+        self.title_lineedit.editingFinished.connect(self.title_editing_finished)
+        if self.settings.get("general", "title"):
+            self.title_lineedit.setText(self.settings.get("general", "title"))
+        title_layout = QtWidgets.QHBoxLayout()
+        title_layout.addWidget(title_label)
+        title_layout.addWidget(self.title_lineedit)
 
         # Whether or not to use an auto-start timer
         self.autostart_timer_checkbox = QtWidgets.QCheckBox()
@@ -162,6 +162,7 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         # Advanced group itself
         advanced_layout = QtWidgets.QVBoxLayout()
         advanced_layout.setContentsMargins(0, 0, 0, 0)
+        advanced_layout.addLayout(title_layout)
         advanced_layout.addLayout(autostart_timer_layout)
         advanced_layout.addLayout(autostop_timer_layout)
         advanced_layout.addWidget(self.legacy_checkbox)
@@ -171,9 +172,8 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         self.advanced_widget.hide()
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addLayout(title_layout)
-        layout.addWidget(self.persistent_checkbox)
         layout.addLayout(self.mode_specific_layout)
+        layout.addWidget(self.persistent_checkbox)
         layout.addWidget(self.public_checkbox)
         layout.addWidget(self.advanced_widget)
         layout.addWidget(self.toggle_advanced_button)
@@ -215,7 +215,8 @@ class ModeSettingsWidget(QtWidgets.QWidget):
                 self.client_auth_checkbox.hide()
 
     def title_editing_finished(self):
-        if self.title_lineedit.text() == "":
+        if self.title_lineedit.text().strip() == "":
+            self.title_lineedit.setText("")
             self.settings.set("general", "title", None)
             if self.tab.mode == self.common.gui.MODE_SHARE:
                 self.tab.change_title.emit(

--- a/desktop/src/onionshare/tab/mode/mode_settings_widget.py
+++ b/desktop/src/onionshare/tab/mode/mode_settings_widget.py
@@ -171,9 +171,9 @@ class ModeSettingsWidget(QtWidgets.QWidget):
         self.advanced_widget.hide()
 
         layout = QtWidgets.QVBoxLayout()
-        layout.addLayout(self.mode_specific_layout)
         layout.addLayout(title_layout)
         layout.addWidget(self.persistent_checkbox)
+        layout.addLayout(self.mode_specific_layout)
         layout.addWidget(self.public_checkbox)
         layout.addWidget(self.advanced_widget)
         layout.addWidget(self.toggle_advanced_button)

--- a/desktop/src/onionshare/tab/mode/receive_mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/receive_mode/__init__.py
@@ -106,6 +106,11 @@ class ReceiveMode(Mode):
             self.hide_webhook_url()
         self.mode_settings_widget.mode_specific_layout.addLayout(webhook_url_layout)
 
+        # Set title placeholder
+        self.mode_settings_widget.title_lineedit.setPlaceholderText(
+            strings._("gui_tab_name_receive")
+        )
+
         # Server status
         self.server_status.set_mode("receive")
         self.server_status.server_started_finished.connect(self.update_primary_action)

--- a/desktop/src/onionshare/tab/mode/share_mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/share_mode/__init__.py
@@ -77,6 +77,11 @@ class ShareMode(Mode):
             for filename in self.filenames:
                 self.file_selection.file_list.add_file(filename)
 
+        # Set title placeholder
+        self.mode_settings_widget.title_lineedit.setPlaceholderText(
+            strings._("gui_tab_name_share")
+        )
+
         # Server status
         self.server_status.set_mode("share", self.file_selection)
         self.server_status.server_started.connect(self.file_selection.server_started)

--- a/desktop/src/onionshare/tab/mode/website_mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/website_mode/__init__.py
@@ -77,6 +77,11 @@ class WebsiteMode(Mode):
             for filename in self.filenames:
                 self.file_selection.file_list.add_file(filename)
 
+        # Set title placeholder
+        self.mode_settings_widget.title_lineedit.setPlaceholderText(
+            strings._("gui_tab_name_website")
+        )
+
         # Server status
         self.server_status.set_mode("website", self.file_selection)
         self.server_status.server_started.connect(self.file_selection.server_started)

--- a/desktop/src/onionshare/tab_widget.py
+++ b/desktop/src/onionshare/tab_widget.py
@@ -188,8 +188,13 @@ class TabWidget(QtWidgets.QTabWidget):
         self.bring_to_front.emit()
 
     def change_title(self, tab_id, title):
+        shortened_title = title
+        if len(shortened_title) > 11:
+            shortened_title = shortened_title[:10] + "..."
+
         index = self.indexOf(self.tabs[tab_id])
-        self.setTabText(index, title)
+        self.setTabText(index, shortened_title)
+        self.setTabToolTip(index, title)
 
     def change_icon(self, tab_id, icon_path):
         index = self.indexOf(self.tabs[tab_id])

--- a/desktop/src/onionshare/tab_widget.py
+++ b/desktop/src/onionshare/tab_widget.py
@@ -178,7 +178,8 @@ class TabWidget(QtWidgets.QTabWidget):
         tab.init(mode_settings)
 
         # Make sure the title is set
-        tab.get_mode().mode_settings_widget.title_editing_finished()
+        if tab.get_mode():
+            tab.get_mode().mode_settings_widget.title_editing_finished()
 
         # If it's persistent, set the persistent image in the tab
         self.change_persistent(tab.tab_id, tab.settings.get("persistent", "enabled"))

--- a/desktop/src/onionshare/tab_widget.py
+++ b/desktop/src/onionshare/tab_widget.py
@@ -176,6 +176,10 @@ class TabWidget(QtWidgets.QTabWidget):
             )
 
         tab.init(mode_settings)
+
+        # Make sure the title is set
+        tab.get_mode().mode_settings_widget.title_editing_finished()
+
         # If it's persistent, set the persistent image in the tab
         self.change_persistent(tab.tab_id, tab.settings.get("persistent", "enabled"))
 


### PR DESCRIPTION
Resolves #1306.

For sake of UX and simplicity I decided to not include the option of setting a custom description and instead just a custom title.

This adds `--title` argument to the CLI, so like:

```sh
onionshare-cli --title "Super Secret Chatz" --chat
```

Looks like:

![Screenshot_2021-04-13_18-43-22](https://user-images.githubusercontent.com/156128/114630247-2aa6ec80-9c88-11eb-8400-6f8c7175071a.png)

I also updated the GUI to allow each tab to let you its title (and re-arranged the settings so title and persistent are at top):

![Screenshot_2021-04-13_18-47-40](https://user-images.githubusercontent.com/156128/114630509-c173a900-9c88-11eb-8d17-760103775c3d.png)

If you don't set a title, the title in Tor Browser is just "OnionShare" and the title of the tab is the mode (e.g. a receive tab is "Receive"). But if you do set a title it renames the tab (and sets a tooltip, so you can see the full name) and also uses the custom title in Tor Browser:

![Screenshot_2021-04-13_18-49-58](https://user-images.githubusercontent.com/156128/114630807-570f3880-9c89-11eb-8390-932d8bf4c8ec.png)
![Screenshot_2021-04-13_18-51-45](https://user-images.githubusercontent.com/156128/114630809-57a7cf00-9c89-11eb-960b-d3978d045516.png)
