### PR TITLE
Use socks5h instead of socks5 

### DIFF
--- a/cli/onionshare_cli/__init__.py
+++ b/cli/onionshare_cli/__init__.py
@@ -376,8 +376,8 @@ def main(cwd=None):
             else:
                 (socks_address, socks_port) = onion.get_tor_socks_port()
                 web.proxies = {
-                    "http": f"socks5://{socks_address}:{socks_port}",
-                    "https": f"socks5://{socks_address}:{socks_port}",
+                    "http": f"socks5h://{socks_address}:{socks_port}",
+                    "https": f"socks5h://{socks_address}:{socks_port}",
                 }
 
         app = OnionShare(common, onion, local_only, autostop_timer)

--- a/desktop/src/onionshare/tab/mode/receive_mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/receive_mode/__init__.py
@@ -275,8 +275,8 @@ class ReceiveMode(Mode):
         else:
             (socks_address, socks_port) = self.common.gui.onion.get_tor_socks_port()
             self.web.proxies = {
-                "http": f"socks5://{socks_address}:{socks_port}",
-                "https": f"socks5://{socks_address}:{socks_port}",
+                "http": f"socks5h://{socks_address}:{socks_port}",
+                "https": f"socks5h://{socks_address}:{socks_port}",
             }
 
     def start_server_step2_custom(self):


### PR DESCRIPTION
With `socks5h` the proxy server resolves the domain name, which avoids leaking DNS requests.

https://github.com/urllib3/urllib3/issues/1035