### PR TITLE
Fetch the Tor version using Stem's get_info('version') rather than get_version(), which is allowed in Tails' control port filter

### DIFF
--- a/cli/onionshare_cli/onion.py
+++ b/cli/onionshare_cli/onion.py
@@ -559,7 +559,7 @@ class Onion(object):
         self.connected_to_tor = True
 
         # Get the tor version
-        self.tor_version = self.c.get_version().version_str
+        self.tor_version = self.c.get_info('version')
         self.common.log("Onion", "connect", f"Connected to tor {self.tor_version}")
 
         # Do the versions of stem and tor that I'm using support ephemeral onion services?


### PR DESCRIPTION
I am hoping this fixes #1309 but I haven't tested it on Tails yet. 

If you still have Tails installed somewhere can you test it out?