### PR TITLE
Update the Content-Security-Policy

### DIFF
--- a/cli/onionshare_cli/web/web.py
+++ b/cli/onionshare_cli/web/web.py
@@ -310,7 +310,7 @@ class Web:
         if not self.settings.get("website", "disable_csp") or self.mode != "website":
             r.headers.set(
                 "Content-Security-Policy",
-                "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self' data:;",
+                "default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; img-src 'self' data:;",
             )
         return r
 


### PR DESCRIPTION
The CSP had `script-src` and `style-src` both set to 'self', which is not necessary since `default-src` is already set to 'self', and these attributes will fall back to `default-src` if not explicitly specified.

Meanwhile, there are several directives in CSP that do *not* fallback to `default-src` if unspecified, meaning they are implicitly allowed (!):

https://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources

`frame-ancestors` and `form-action` are the most important ones to set (the former should be none to prevent embedding the page in an iframe - CSP's equivalent of `X-Frame-Options: deny`, and the latter should be set to 'self' to allow our Receive mode's form to submit)

`base-uri` I think is less significant for us (we don't use `<base>` HTML element with relative links), but I set it to self too so that it can't somehow be set to something else.

Other directives `report-uri` and `plugin-types` do not inherit `default-src` but are deprecated so I'm ignoring them.