### PR TITLE
Re-instate the locale key string error_tor_protocol_error

### DIFF
--- a/desktop/src/onionshare/resources/locale/en.json
+++ b/desktop/src/onionshare/resources/locale/en.json
@@ -194,5 +194,5 @@
     "gui_rendezvous_cleanup": "Waiting for Tor circuits to close to be sure your files have successfully transferred.\n\nThis might take a few minutes.",
     "gui_rendezvous_cleanup_quit_early": "Quit Early",
     "error_port_not_available": "OnionShare port not available",
-    "error_tor_protocol_error": "OnionShare experienced a protocol error with Tor:\n{}"
+    "error_tor_protocol_error": "There was an error with Tor: {}"
 }

--- a/desktop/src/onionshare/resources/locale/en.json
+++ b/desktop/src/onionshare/resources/locale/en.json
@@ -193,5 +193,6 @@
     "settings_error_bundled_tor_broken": "OnionShare could not connect to Tor:\n{}",
     "gui_rendezvous_cleanup": "Waiting for Tor circuits to close to be sure your files have successfully transferred.\n\nThis might take a few minutes.",
     "gui_rendezvous_cleanup_quit_early": "Quit Early",
-    "error_port_not_available": "OnionShare port not available"
+    "error_port_not_available": "OnionShare port not available",
+    "error_tor_protocol_error": "OnionShare experienced a protocol error with Tor:\n{}"
 }


### PR DESCRIPTION
... for surfacing Alert dialogs in the UI when Stem throws a ProtocolError back from Tor


I've been working on a [branch](https://github.com/mig5/onionshare/tree/client_auth_v3) for ClientAuth support in v3 onions, which required me to run a much newer nightly version of Tor.

That newer Tor (0.4.7 alpha-dev) has dropped support for v2 onions entirely. 

When trying the 'legacy' onion mode in OnionShare, a fatal error was thrown because Tor threw a ProtocolError back to Stem. This is expected, and we try to throw an Alert dialog in the UI for the ProtocolError, but for some reason we have dropped the actual key from our locale, which caused this traceback:

```
[May 04 2021 09:33:33 AM] Onion.start_onion_service: port=17632
[May 04 2021 09:33:33 AM] Onion.start_onion_service: key_type=NEW, key_content=RSA1024
Tor error: ADD_ONION response didn't have an OK status: Invalid key type
Traceback (most recent call last):
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/onionshare_cli/onion.py", line 729, in start_onion_service
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/stem/control.py", line 3131, in create_ephemeral_hidden_service
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/stem/response/__init__.py", line 124, in convert
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/stem/response/add_onion.py", line 33, in _parse_message
stem.ProtocolError: ADD_ONION response didn't have an OK status: Invalid key type

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/git/onionshare/desktop/src/onionshare/threads.py", line 89, in run
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/onionshare_cli/onionshare.py", line 80, in start_onion_service
  File "/home/user/git/onionshare/desktop/venv/lib/python3.7/site-packages/onionshare_cli/onion.py", line 734, in start_onion_service
onionshare_cli.onion.TorErrorProtocolError: ADD_ONION response didn't have an OK status: Invalid key type

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/git/onionshare/desktop/src/onionshare/threads.py", line 113, in run
  File "/home/user/git/onionshare/desktop/src/onionshare/gui_common.py", line 436, in get_translated_tor_error
  File "/home/user/git/onionshare/desktop/src/onionshare/strings.py", line 56, in translated
KeyError: 'error_tor_protocol_error'
```

This reinstates the key, which thus returns the Alert dialog and a graceful error rather than a freeze