### PR TITLE
Some small corrections and additions to the CHANGELOG for v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 2.3.2
 
-* New feature: Receive mode supports custom titles
+* New feature: Custom titles can be set for OnionShare's various modes
 * New feature: Receive mode supports notification webhooks
-* New feature: Receive mode supports submitting messages as well files
+* New feature: Receive mode supports submitting messages as well as files
 * New feature: New ASCII art banner and prettier verbose output
 * New feature: Partial support for range requests (pausing and resuming in HTTP)
+* Updated Tor to 0.4.5.7
+* Updated built-in obfs4 bridges
 * Various bug fixes
 
 ## 2.3.1


### PR DESCRIPTION
Just wanted to clarify that Custom titles is a feature for all modes (not just Receive mode). While I was there, added some other small details.