### PR TITLE
Account for the "v" in the version string ("v2.3.2") banner spacing

### DIFF
--- a/cli/onionshare_cli/common.py
+++ b/cli/onionshare_cli/common.py
@@ -250,7 +250,7 @@ class Common:
         )
         left_spaces = (43 - len(self.version) - 1) // 2
         right_spaces = left_spaces
-        if left_spaces + len(self.version) + right_spaces < 43:
+        if left_spaces + len(self.version) + 1 + right_spaces < 43:
             right_spaces += 1
         print(
             Back.MAGENTA


### PR DESCRIPTION
Fixes #1350.

![Screenshot at 2021-05-25 17-32-14](https://user-images.githubusercontent.com/156128/119585239-d54b1880-bdb9-11eb-93ea-23b480d4a996.png)
