### PR TITLE
Make it impossible to cancel a share mid-startup, to avoid a thread segfault issue. 

### DIFF
--- a/desktop/src/onionshare/resources/locale/en.json
+++ b/desktop/src/onionshare/resources/locale/en.json
@@ -33,7 +33,7 @@
     "gui_show_url_qr_code": "Show QR Code",
     "gui_qr_code_dialog_title": "OnionShare QR Code",
     "gui_waiting_to_start": "Scheduled to start in {}. Click to cancel.",
-    "gui_please_wait": "Starting… Click to cancel.",
+    "gui_please_wait": "Starting…",
     "error_rate_limit": "Someone has made too many wrong attempts to guess your password, so OnionShare has stopped the server. Start sharing again and send the recipient a new address to share.",
     "zip_progress_bar_format": "Compressing: %p%",
     "gui_settings_window_title": "Settings",

--- a/desktop/src/onionshare/tab/mode/__init__.py
+++ b/desktop/src/onionshare/tab/mode/__init__.py
@@ -354,14 +354,6 @@ class Mode(QtWidgets.QWidget):
             self.app.onion.scheduled_key = None
             self.app.onion.scheduled_auth_cookie = None
             self.startup_thread.quit()
-        if self.onion_thread:
-            self.common.log("Mode", "cancel_server: quitting onion thread")
-            self.onion_thread.terminate()
-            self.onion_thread.wait()
-        if self.web_thread:
-            self.common.log("Mode", "cancel_server: quitting web thread")
-            self.web_thread.terminate()
-            self.web_thread.wait()
         self.stop_server()
 
     def cancel_server_custom(self):

--- a/desktop/src/onionshare/tab/server_status.py
+++ b/desktop/src/onionshare/tab/server_status.py
@@ -379,7 +379,7 @@ class ServerStatus(QtWidgets.QWidget):
                 self.start_server()
         elif self.status == self.STATUS_STARTED:
             self.stop_server()
-        elif self.status == self.STATUS_WORKING:
+        elif self.status == self.STATUS_WORKING and self.settings.get("general", "autostart_timer"):
             self.cancel_server()
         self.button_clicked.emit()
 


### PR DESCRIPTION
As discussed

Closes #1362 

With this change, it should only be possible to cancel a share if it was scheduled to start in auto-start mode. The button cannot be clicked anymore mid-startup in other scenarios.

Technically still a very small window where the auto-started share is actually starting up right at the scheduled time, and not yet started, where it can still be clicked: but to me it seems a small corner case - it requires the user to be present (thus doesn't impede the dead man switch feature) and if so, the user can close OnionShare altogether or stop the share after it starts.