### PR TITLE
Set the Max-Width of the Chat-Window to 80%

### DIFF
--- a/cli/onionshare_cli/resources/static/css/style.css
+++ b/cli/onionshare_cli/resources/static/css/style.css
@@ -202,6 +202,7 @@ ul.breadcrumbs li a:link, ul.breadcrumbs li a:visited {
 }
 
 .chat-wrapper {
+  max-width: 80%;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/cli/onionshare_cli/resources/static/css/style.css
+++ b/cli/onionshare_cli/resources/static/css/style.css
@@ -202,7 +202,6 @@ ul.breadcrumbs li a:link, ul.breadcrumbs li a:visited {
 }
 
 .chat-wrapper {
-  max-width: 80%;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -230,6 +229,7 @@ ul.breadcrumbs li a:link, ul.breadcrumbs li a:visited {
   display: block;
 }
 .chat-wrapper .message {
+  word-break: break-word;
   font-weight: normal;
   display: block;
   margin-bottom: 0.3em;


### PR DESCRIPTION
Too long single-line messages can cause the ChatUser-Panel to disappear.
Allowing the windows of the Chat to be only 80% of width will cause a automatic linebreak in such a case.