### PR TITLE
 #1377 The Update-URL now links to the official OnionShare-Website instead of the Github-Release-Page

### DIFF
--- a/desktop/src/onionshare/update_checker.py
+++ b/desktop/src/onionshare/update_checker.py
@@ -168,7 +168,7 @@ class UpdateChecker(QtCore.QObject):
             settings.save()
 
             # Do we need to update?
-            update_url = f"https://github.com/micahflee/onionshare/releases/tag/v{latest_version}"
+            update_url = "https://onionshare.org"
             installed_version = self.common.version
             if installed_version < latest_version:
                 self.update_available.emit(


### PR DESCRIPTION
As issued by micahflee in the Issue #1377