### PR TITLE
Update Tor Browser download scripts

### DIFF
--- a/desktop/scripts/get-tor-osx.py
+++ b/desktop/scripts/get-tor-osx.py
@@ -34,10 +34,10 @@ import requests
 
 
 def main():
-    dmg_url = "https://www.torproject.org/dist/torbrowser/10.0.16/TorBrowser-10.0.16-osx64_en-US.dmg"
-    dmg_filename = "TorBrowser-10.0.16-osx64_en-US.dmg"
+    dmg_url = "https://dist.torproject.org/torbrowser/10.0.18/TorBrowser-10.0.18-osx64_en-US.dmg"
+    dmg_filename = "TorBrowser-10.0.18-osx64_en-US.dmg"
     expected_dmg_sha256 = (
-        "95bf37d642bd05e9ae4337c5ab9706990bbd98cc885e25ee8ae81b07c7653f0a"
+        "d7e92e3803e65f11541555eb04b828feb9e8c98cf2cb1391692ade091bfb8b5f"
     )
 
     # Build paths

--- a/desktop/scripts/get-tor-windows.py
+++ b/desktop/scripts/get-tor-windows.py
@@ -33,10 +33,10 @@ import requests
 
 
 def main():
-    exe_url = "https://www.torproject.org/dist/torbrowser/10.0.16/torbrowser-install-10.0.16_en-US.exe"
-    exe_filename = "torbrowser-install-10.0.16_en-US.exe"
+    exe_url = "https://dist.torproject.org/torbrowser/10.0.18/torbrowser-install-10.0.18_en-US.exe"
+    exe_filename = "torbrowser-install-10.0.18_en-US.exe"
     expected_exe_sha256 = (
-        "1f93d756b4aee1b2df7d85c8d58b626b0d38d89c974c0a02f324ff51f5b23ee1"
+        "a42f31fc7abe322e457d9f69bae76f935b7ab0a6f9d137d00b6dcc9974ca6e10"
     )
     # Build paths
     root_path = os.path.dirname(


### PR DESCRIPTION
The 10.0.16 Tor Browser URLs were no longer up, so upgrade to 10.0.18.